### PR TITLE
Reduce scoped recall and repository identity overhead

### DIFF
--- a/src/code_graph/repository.ts
+++ b/src/code_graph/repository.ts
@@ -1,11 +1,14 @@
 import {Effect, FileSystem, Path} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {type CommandExecutor, runBinaryCommandEffect, runCommandEffect} from '../effect/command.js';
+import {succeedUndefined} from '../effect/optional.js';
 import {platformPathFor, SystemInfo} from '../effect/system.js';
 import {CodeGraphRepositoryError, type RepositoryIdentity, type RepositoryIdentityExpectation} from './types.js';
 
 const IDENTITY_FORMAT_VERSION = 1;
 const GIT_DIRECTORY_OUTPUT_BYTES_MAXIMUM = 16 * 1_024;
+const GIT_TEXT_OUTPUT_BYTES_MAXIMUM = 2 * 1_048_576;
+const REPOSITORY_METADATA_BYTES_MAXIMUM = GIT_TEXT_OUTPUT_BYTES_MAXIMUM + GIT_DIRECTORY_OUTPUT_BYTES_MAXIMUM + 128;
 const REPOSITORY_STATUS_OBSERVATION_BYTES_MAXIMUM = 64 * 1_024;
 
 export const CODE_GRAPH_WORKTREE_REGISTRY_LIMITS = {
@@ -29,29 +32,64 @@ interface RegisteredRepositoryWorktree extends RepositoryWorktreeRegistryIdentit
 export const resolveRepositoryIdentityDetail = Effect.fn('codeGraph.resolveRepositoryIdentityDetail')(function* (
   cwd: string,
 ) {
+  const result = yield* runBinaryCommandEffect(
+    'git',
+    [
+      '-C',
+      cwd,
+      'rev-parse',
+      '--path-format=absolute',
+      '--show-toplevel',
+      '--git-common-dir',
+      '--git-dir',
+      '--show-object-format',
+      'HEAD',
+    ],
+    {maxOutputBytes: REPOSITORY_METADATA_BYTES_MAXIMUM, timeoutMs: 30_000},
+  ).pipe(
+    Effect.catchTag('CommandFailed', () => succeedUndefined),
+    Effect.mapError(cause => CodeGraphRepositoryError.make({message: `Not a Git repository: ${cause.message}`})),
+  );
+  // An unborn HEAD or an ambiguous frame must repeat complete discovery at the
+  // original caller. Never combine a partial batch with later fallback fields.
+  const metadata = result?.exitCode === 0 ? parseRepositoryIdentityMetadata(result.stdout) : undefined;
+  return yield* resolveRepositoryIdentityDetailFromObservation(cwd, metadata);
+});
+
+const resolveRepositoryIdentityDetailFromObservation = Effect.fn(
+  'codeGraph.resolveRepositoryIdentityDetailFromObservation',
+)(function* (cwd: string, metadata: RepositoryIdentityMetadata | undefined) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
-  const rootResult = yield* runGit(cwd, ['rev-parse', '--show-toplevel']).pipe(
-    Effect.mapError(cause => CodeGraphRepositoryError.make({message: `Not a Git repository: ${cause.message}`})),
-  );
+  const rootResult =
+    metadata === undefined
+      ? yield* runGit(cwd, ['rev-parse', '--show-toplevel']).pipe(
+          Effect.mapError(cause => CodeGraphRepositoryError.make({message: `Not a Git repository: ${cause.message}`})),
+        )
+      : {stdout: metadata.repoRoot};
   const repoRoot = yield* fs.realPath(rootResult.stdout.trim());
-  const [directoryResult, formatResult, commitResult, ignoreCaseResult, remoteResult, branch] = yield* Effect.all(
+  const [directories, formatResult, commitResult, ignoreCaseResult, remoteResult, branch] = yield* Effect.all(
     [
-      runBinaryCommandEffect(
-        'git',
-        ['-C', repoRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir', '--git-dir'],
-        {maxOutputBytes: GIT_DIRECTORY_OUTPUT_BYTES_MAXIMUM, timeoutMs: 30_000},
-      ),
-      runGit(repoRoot, ['rev-parse', '--show-object-format']),
-      runGit(repoRoot, ['rev-parse', 'HEAD'], true),
+      metadata === undefined
+        ? runBinaryCommandEffect(
+            'git',
+            ['-C', repoRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir', '--git-dir'],
+            {maxOutputBytes: GIT_DIRECTORY_OUTPUT_BYTES_MAXIMUM, timeoutMs: 30_000},
+          ).pipe(Effect.map(result => parseGitDirectoryOutput(result.stdout)))
+        : Effect.succeed(metadata),
+      metadata === undefined
+        ? runGit(repoRoot, ['rev-parse', '--show-object-format'])
+        : Effect.succeed({stdout: metadata.objectFormat}),
+      metadata === undefined
+        ? runGit(repoRoot, ['rev-parse', 'HEAD'], true)
+        : Effect.succeed({exitCode: 0, stdout: metadata.headCommit}),
       runGit(repoRoot, ['config', '--bool', 'core.ignorecase'], true),
       runGit(repoRoot, ['remote', 'get-url', 'origin'], true),
       observeRepositoryBranch(repoRoot),
     ],
     {concurrency: 6},
   );
-  const directories = parseGitDirectoryOutput(directoryResult.stdout);
   if (directories === undefined) {
     return yield* CodeGraphRepositoryError.make({message: 'Git repository directory metadata is invalid.'});
   }
@@ -85,6 +123,37 @@ export const resolveRepositoryIdentityDetail = Effect.fn('codeGraph.resolveRepos
   } satisfies RepositoryIdentity;
   return {gitDirectory: directories.gitDirectory, identity};
 });
+
+interface RepositoryIdentityMetadata {
+  readonly repoRoot: string;
+  readonly commonDirectory: string;
+  readonly gitDirectory: string;
+  readonly objectFormat: 'sha1' | 'sha256';
+  readonly headCommit: string;
+}
+
+/** @internal Successful bounded Git metadata only; undefined requests fresh legacy discovery. */
+export function parseRepositoryIdentityMetadata(output: Uint8Array): RepositoryIdentityMetadata | undefined {
+  if (output.byteLength === 0 || output.byteLength > REPOSITORY_METADATA_BYTES_MAXIMUM) return undefined;
+  try {
+    const decoded = new TextDecoder('utf-8', {fatal: true, ignoreBOM: true}).decode(output);
+    if (!decoded.endsWith('\n')) return undefined;
+    const records = decoded.slice(0, -1).split('\n');
+    if (records.length !== 5 || records.some(record => !record || record.includes('\0') || record.includes('\r'))) {
+      return undefined;
+    }
+    const [repoRoot, commonDirectory, gitDirectory, objectFormat, headCommit] = records;
+    // Full discovery trims the root output. Preserve that behavior by declining
+    // the fast path for roots whose edge whitespace would select a different path.
+    if (repoRoot !== repoRoot.trim() || byteLength(`${repoRoot}\n`) > GIT_TEXT_OUTPUT_BYTES_MAXIMUM) return undefined;
+    if (byteLength(`${commonDirectory}\n${gitDirectory}\n`) > GIT_DIRECTORY_OUTPUT_BYTES_MAXIMUM) return undefined;
+    if (objectFormat !== 'sha1' && objectFormat !== 'sha256') return undefined;
+    if (!(objectFormat === 'sha1' ? /^[0-9a-f]{40}$/u : /^[0-9a-f]{64}$/u).test(headCommit)) return undefined;
+    return {repoRoot, commonDirectory, gitDirectory, objectFormat, headCommit};
+  } catch {
+    return undefined;
+  }
+}
 
 export function normalizeRepositoryBranchName(value: string): string | undefined {
   const branch = value.trim();
@@ -680,7 +749,7 @@ export function repositoryIdentityMatchesExpectation(
 function runGit(cwd: string, args: readonly string[], allowFailure = false) {
   return runCommandEffect('git', ['-C', cwd, ...args], {
     allowFailure,
-    maxOutputBytes: 2 * 1_048_576,
+    maxOutputBytes: GIT_TEXT_OUTPUT_BYTES_MAXIMUM,
     timeoutMs: 30_000,
   });
 }

--- a/src/recall/index_selection.ts
+++ b/src/recall/index_selection.ts
@@ -365,13 +365,17 @@ export function selectRecallQueryTermStatistics(
        )`,
       scope.params,
     );
+    // A URI range hint prevents rowid lookup from a matching term posting and
+    // can rescan the authorized range for each match. Keep authorization in
+    // WHERE while allowing that lookup; retain workspace-only access plans.
+    const frequencyIndexHint = uriScope.restricted ? '' : indexHint;
     const frequencies: Array<{readonly document_frequency: number; readonly term: string}> = [];
     for (let index = 0; index < terms.length; index += 300) {
       const batch = terms.slice(index, index + 300);
       frequencies.push(
         ...(yield* sql.unsafe<{readonly document_frequency: number; readonly term: string}>(
           `SELECT p.term, COUNT(DISTINCT d.logical_key) AS document_frequency
-           FROM documents AS d${indexHint}
+           FROM documents AS d${frequencyIndexHint}
            INNER JOIN postings AS p ON p.document_id = d.id
            WHERE p.term IN (${batch.map(() => '?').join(', ')})
              AND ${scope.sql}

--- a/test/integration/code-graph.view-attach-lock.test.ts
+++ b/test/integration/code-graph.view-attach-lock.test.ts
@@ -131,7 +131,7 @@ describe('shared ready view attachment locking', () => {
         if (executable !== 'git') return;
         counts.git += 1;
         if (args.includes('symbolic-ref')) counts.branchObservation += 1;
-        if (args[2] === 'rev-parse' && args[3] === '--show-toplevel') counts.fullIdentity += 1;
+        if (args[2] === 'rev-parse' && args.includes('--show-toplevel')) counts.fullIdentity += 1;
         if (args[2] === 'status') {
           counts.status += 1;
           if (args.includes('--porcelain=v2')) counts.publicationProof += 1;
@@ -165,7 +165,7 @@ describe('shared ready view attachment locking', () => {
       expect(observed.elapsedMilliseconds).toBeLessThan(500);
       expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
       expect(observed.attached.stale).toBe(false);
-      expect(observed.counts).toEqual({branchObservation: 1, fullIdentity: 1, git: 15, publicationProof: 1, status: 2});
+      expect(observed.counts).toEqual({branchObservation: 1, fullIdentity: 1, git: 12, publicationProof: 1, status: 2});
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 

--- a/test/unit/code-graph.local-provenance.test.ts
+++ b/test/unit/code-graph.local-provenance.test.ts
@@ -19,10 +19,15 @@ import {
 import {homedir, tmpdir} from '../helpers/node-os.js';
 import {basename, dirname, join, sep} from '../helpers/node-path.js';
 import {afterEach} from 'vitest';
-import {describe, expect, it} from '@effect/vitest';
-import {Effect, FileSystem, Option, PlatformError} from 'effect';
+import {describe, expect, it, it as effectIt} from '@effect/vitest';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {Effect, FileSystem, Layer, Option, Path, PlatformError} from 'effect';
+import {TestClock} from 'effect/testing';
 import * as FC from 'effect/testing/FastCheck';
-import {CommandExecutor} from '../../src/effect/command.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
 import {
   parseCodeGraphLocalProvenanceRecordJson,
   privacySafeCodeGraphLocalAssociation,
@@ -326,70 +331,67 @@ describe('code graph private local provenance', () => {
     expect(readdirSync(dirname(fixture.sidecar)).filter(name => name.endsWith('.tmp'))).toEqual([]);
   });
 
-  it('uses one complete Git resolution per concurrent cadence-hit status observation', async () => {
-    const fixture = await provenanceFixture();
-    await runEffect(recordVerifiedCodeGraphLocalAssociation(fixture.home, fixture.identity));
-    let gitInvocationCount = 0;
-    let branchObservationCount = 0;
-    let interlockCount = 0;
+  effectIt.effect('uses one complete Git resolution per concurrent cadence-hit status observation', () =>
+    Effect.gen(function* () {
+      const fixture = yield* effectProvenanceFixture();
+      yield* recordVerifiedCodeGraphLocalAssociation(fixture.home, fixture.identity);
+      let gitInvocationCount = 0;
+      let branchObservationCount = 0;
+      let interlockCount = 0;
 
-    const statuses = await runEffect(
-      Effect.gen(function* () {
-        const command = yield* CommandExecutor;
-        const query = yield* CodeGraphQueryService;
-        const executeBytes = command.executeBytes;
-        if (executeBytes === undefined)
-          return yield* TestError.make({message: 'binary command adapter is unavailable'});
-        const mutableCommand = command as {
-          execute: typeof command.execute;
-          executeBytes: typeof executeBytes;
-        };
-        const execute = command.execute;
-        return yield* Effect.acquireUseRelease(
-          Effect.sync(() => {
-            mutableCommand.execute = (executable, args, options) => {
-              if (executable === 'git') {
-                gitInvocationCount += 1;
-                if (args.includes('symbolic-ref')) branchObservationCount += 1;
-              }
-              return execute(executable, args, options);
-            };
-            mutableCommand.executeBytes = (executable, args, options) => {
-              if (executable === 'git') {
-                gitInvocationCount += 1;
-                if (args.includes('symbolic-ref')) branchObservationCount += 1;
-              }
-              return executeBytes(executable, args, options);
-            };
-          }),
-          () =>
-            Effect.all(
-              Array.from({length: 16}, () =>
-                query.status(fixture.home, fixture.root, {
-                  afterIdentityObserved: () =>
-                    Effect.sync(() => {
-                      interlockCount += 1;
-                    }),
-                  observeWorktree: false,
-                }),
-              ),
-              {concurrency: 'unbounded'},
+      const command = yield* CommandExecutor;
+      const query = yield* CodeGraphQueryService;
+      const executeBytes = command.executeBytes;
+      if (executeBytes === undefined) return yield* TestError.make({message: 'binary command adapter is unavailable'});
+      const mutableCommand = command as {
+        execute: typeof command.execute;
+        executeBytes: typeof executeBytes;
+      };
+      const execute = command.execute;
+      const statuses = yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          mutableCommand.execute = (executable, args, options) => {
+            if (executable === 'git') {
+              gitInvocationCount += 1;
+              if (args.includes('symbolic-ref')) branchObservationCount += 1;
+            }
+            return execute(executable, args, options);
+          };
+          mutableCommand.executeBytes = (executable, args, options) => {
+            if (executable === 'git') {
+              gitInvocationCount += 1;
+              if (args.includes('symbolic-ref')) branchObservationCount += 1;
+            }
+            return executeBytes(executable, args, options);
+          };
+        }),
+        () =>
+          Effect.all(
+            Array.from({length: 16}, () =>
+              query.status(fixture.home, fixture.root, {
+                afterIdentityObserved: () =>
+                  Effect.sync(() => {
+                    interlockCount += 1;
+                  }),
+                observeWorktree: false,
+              }),
             ),
-          () =>
-            Effect.sync(() => {
-              mutableCommand.execute = execute;
-              mutableCommand.executeBytes = executeBytes;
-            }),
-        );
-      }),
-    );
+            {concurrency: 'unbounded'},
+          ),
+        () =>
+          Effect.sync(() => {
+            mutableCommand.execute = execute;
+            mutableCommand.executeBytes = executeBytes;
+          }),
+      );
 
-    expect(statuses).toHaveLength(16);
-    expect(statuses.every(status => status.identity.repositoryId === fixture.identity.repositoryId)).toBe(true);
-    expect(interlockCount).toBe(16);
-    expect(branchObservationCount).toBe(16);
-    expect(gitInvocationCount).toBe(16 * 7);
-  });
+      expect(statuses).toHaveLength(16);
+      expect(statuses.every(status => status.identity.repositoryId === fixture.identity.repositoryId)).toBe(true);
+      expect(interlockCount).toBe(16);
+      expect(branchObservationCount).toBe(16);
+      expect(gitInvocationCount).toBe(16 * 4);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
 
   it('distinguishes a legacy checkout, an absent exact record, and a moved worktree', async () => {
     const fixture = await provenanceFixture();
@@ -523,52 +525,58 @@ describe('code graph private local provenance', () => {
     expect(gitInvocationCount).toBe(0);
   });
 
-  it('refreshes an expired display observation once and reuses the newly published cadence', async () => {
-    const fixture = await provenanceFixture();
-    await runEffect(recordVerifiedCodeGraphLocalAssociation(fixture.home, fixture.identity));
-    const expiredObservedAt = '2020-01-01T00:00:00.000Z';
-    writeFileSync(
-      fixture.sidecar,
-      `${JSON.stringify({...readRecord(fixture.sidecar), observedAt: expiredObservedAt})}\n`,
-      {mode: 0o600},
-    );
-    let identityResolutionCount = 0;
+  effectIt.effect('refreshes an expired display observation once and reuses the newly published cadence', () =>
+    Effect.gen(function* () {
+      const fixture = yield* effectProvenanceFixture();
+      const fs = yield* FileSystem.FileSystem;
+      yield* recordVerifiedCodeGraphLocalAssociation(fixture.home, fixture.identity);
+      const expiredObservedAt = '2020-01-01T00:00:00.000Z';
+      const record = JSON.parse(yield* fs.readFileString(fixture.sidecar)) as CodeGraphLocalProvenanceRecord;
+      yield* fs.writeFileString(fixture.sidecar, `${JSON.stringify({...record, observedAt: expiredObservedAt})}\n`, {
+        mode: 0o600,
+      });
+      let identityResolutionCount = 0;
 
-    const result = await runEffect(
-      Effect.gen(function* () {
-        const command = yield* CommandExecutor;
-        const mutableCommand = command as {execute: typeof command.execute};
-        const execute = command.execute;
-        return yield* Effect.acquireUseRelease(
-          Effect.sync(() => {
-            mutableCommand.execute = (executable, args, options) => {
-              if (executable === 'git' && args[2] === 'rev-parse' && args[3] === '--show-toplevel') {
-                identityResolutionCount += 1;
-              }
-              return execute(executable, args, options);
-            };
+      const command = yield* CommandExecutor;
+      const executeBytes = command.executeBytes;
+      if (executeBytes === undefined) return yield* TestError.make({message: 'binary command adapter is unavailable'});
+      const mutableCommand = command as {execute: typeof command.execute; executeBytes: typeof executeBytes};
+      const execute = command.execute;
+      const result = yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          mutableCommand.execute = (executable, args, options) => {
+            if (executable === 'git' && args.includes('rev-parse') && args.includes('--show-toplevel')) {
+              identityResolutionCount += 1;
+            }
+            return execute(executable, args, options);
+          };
+          mutableCommand.executeBytes = (executable, args, options) => {
+            if (executable === 'git' && args.includes('rev-parse') && args.includes('--show-toplevel'))
+              identityResolutionCount += 1;
+            return executeBytes(executable, args, options);
+          };
+        }),
+        () =>
+          Effect.gen(function* () {
+            const first = yield* readPersistedCodeGraphLocalAssociation(fixture.home, fixture.identity);
+            const afterFirstResolutionCount = identityResolutionCount;
+            const second = yield* readPersistedCodeGraphLocalAssociation(fixture.home, fixture.identity);
+            return {afterFirstResolutionCount, first, second};
           }),
-          () =>
-            Effect.gen(function* () {
-              const first = yield* readPersistedCodeGraphLocalAssociation(fixture.home, fixture.identity);
-              const afterFirstResolutionCount = identityResolutionCount;
-              const second = yield* readPersistedCodeGraphLocalAssociation(fixture.home, fixture.identity);
-              return {afterFirstResolutionCount, first, second};
-            }),
-          () =>
-            Effect.sync(() => {
-              mutableCommand.execute = execute;
-            }),
-        );
-      }),
-    );
+        () =>
+          Effect.sync(() => {
+            mutableCommand.execute = execute;
+            mutableCommand.executeBytes = executeBytes;
+          }),
+      );
 
-    expect(result.first).toMatchObject({available: true, path: fixture.root, state: 'verified'});
-    expect(result.second).toMatchObject({available: true, path: fixture.root, state: 'verified'});
-    expect('observedAt' in result.first ? result.first.observedAt : undefined).not.toBe(expiredObservedAt);
-    expect(result.afterFirstResolutionCount).toBe(2);
-    expect(identityResolutionCount).toBe(2);
-  });
+      expect(result.first).toMatchObject({available: true, path: fixture.root, state: 'verified'});
+      expect(result.second).toMatchObject({available: true, path: fixture.root, state: 'verified'});
+      expect('observedAt' in result.first ? result.first.observedAt : undefined).not.toBe(expiredObservedAt);
+      expect(result.afterFirstResolutionCount).toBe(2);
+      expect(identityResolutionCount).toBe(2);
+    }).pipe(provideTestLayer(provenancePlatformLayer), TestClock.withLive),
+  );
 
   it('rejects permissive, malformed, non-absolute, and mismatched records without displaying their paths', async () => {
     const fixture = await provenanceFixture();
@@ -820,6 +828,56 @@ describe('code graph private local provenance', () => {
     },
     {fastCheck: {numRuns: 200}},
   );
+});
+
+const provenancePlatformLayer = Layer.mergeAll(
+  SystemInfo.layer,
+  CommandExecutor.layer.pipe(Layer.provide(SystemInfo.layer)),
+).pipe(Layer.provideMerge(BunServices.layer));
+
+const effectProvenanceFixture = Effect.fn('localProvenanceTest.effectFixture')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const temporary = yield* Effect.acquireRelease(
+    fs.makeTempDirectory({prefix: 'threadnote-provenance-effect-'}),
+    directory => fs.remove(directory, {recursive: true, force: true}).pipe(Effect.orDie),
+  );
+  const home = path.join(temporary, 'home');
+  const repository = path.join(temporary, 'repository');
+  yield* fs.makeDirectory(home);
+  yield* fs.makeDirectory(repository);
+  yield* runCommandEffect('git', ['-C', repository, 'init', '-q', '-b', 'main']);
+  yield* runCommandEffect('git', [
+    '-C',
+    repository,
+    '-c',
+    'commit.gpgsign=false',
+    '-c',
+    'user.name=Threadnote Test',
+    '-c',
+    'user.email=test@threadnote.local',
+    'commit',
+    '--allow-empty',
+    '-qm',
+    'fixture',
+  ]);
+  const root = yield* fs.realPath(repository);
+  const identity = yield* resolveRepositoryIdentity(root);
+  return {
+    home,
+    identity,
+    root,
+    sidecar: path.join(
+      home,
+      'indexes',
+      'code-graph',
+      'repositories',
+      identity.checkoutId,
+      'local-context',
+      'worktrees',
+      `${identity.worktreeId}.json`,
+    ),
+  };
 });
 
 async function provenanceFixture(parent?: string): Promise<{

--- a/test/unit/code-graph.repository-metadata-batch.test.ts
+++ b/test/unit/code-graph.repository-metadata-batch.test.ts
@@ -1,0 +1,344 @@
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- Effect's symlink API lacks the junction type required for unprivileged Windows fixtures.
+import {symlinkSync} from 'node:fs';
+import {it as effectIt} from '@effect/vitest';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {parseRepositoryIdentityMetadata, resolveRepositoryIdentityDetail} from '../../src/code_graph/repository.js';
+import {
+  CommandExecutor,
+  CommandOutputLimitExceeded,
+  CommandSpawnFailed,
+  CommandTimedOut,
+  runCommandEffect,
+} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const utf8 = new TextEncoder();
+const rootLimit = 2 * 1_048_576;
+const directoryLimit = 16 * 1_024;
+type Commands = Parameters<typeof CommandExecutor.of>[0];
+type Invocation = {readonly kind: 'text' | 'bytes'; readonly args: readonly string[]};
+const platformLayer = Layer.mergeAll(
+  SystemInfo.layer,
+  CommandExecutor.layer.pipe(Layer.provide(SystemInfo.layer)),
+).pipe(Layer.provideMerge(BunServices.layer));
+
+describe('repository metadata batching', () => {
+  it('round-trips complete byte frames without changing their fields or input bytes', () => {
+    const segment = fc
+      .array(fc.constantFrom('a', 'Z', '0', ' ', '.', '-', '_', 'é', '東', '🦉', '\\'), {
+        minLength: 1,
+        maxLength: 40,
+      })
+      .map(characters => characters.join(''));
+    fc.assert(
+      fc.property(segment, segment, fc.constantFrom('sha1' as const, 'sha256' as const), (root, admin, format) => {
+        const expected = {
+          repoRoot: `/repository/${root}/root`,
+          commonDirectory: `/metadata/${admin}/common`,
+          gitDirectory: `/metadata/${admin}/linked`,
+          objectFormat: format,
+          headCommit: 'a'.repeat(format === 'sha1' ? 40 : 64),
+        };
+        const bytes = frame(expected);
+        const before = bytes.slice();
+        expect(parseRepositoryIdentityMetadata(bytes)).toEqual(expected);
+        expect(bytes).toEqual(before);
+      }),
+      {numRuns: 100},
+    );
+  });
+
+  it('declines malformed, partial, ambiguous, and format-mismatched frames', () => {
+    const base = ['/repo', '/common', '/git', 'sha1', 'a'.repeat(40)];
+    const malformed = [
+      '',
+      base.join('\n'),
+      `${base.join('\n')}\nextra\n`,
+      `${base.slice(0, -1).join('\n')}\n`,
+      `${base.map((value, index) => (index === 1 ? '' : value)).join('\n')}\n`,
+      `${base.join('\r\n')}\r\n`,
+      `${base.join('\n')}\n\0`,
+      `${[' /repo', ...base.slice(1)].join('\n')}\n`,
+      `${['/repo ', ...base.slice(1)].join('\n')}\n`,
+      `${['/repo', '/common\0suffix', ...base.slice(2)].join('\n')}\n`,
+      `${[...base.slice(0, 3), 'sha512', base[4]].join('\n')}\n`,
+      `${[...base.slice(0, 4), 'A'.repeat(40)].join('\n')}\n`,
+      `${[...base.slice(0, 3), 'sha256', base[4]].join('\n')}\n`,
+      `${[...base.slice(0, 4), 'HEAD'].join('\n')}\n`,
+    ];
+    for (const output of malformed) expect(parseRepositoryIdentityMetadata(utf8.encode(output))).toBeUndefined();
+    const invalidUtf8 = utf8.encode(`${base.join('\n')}\n`);
+    invalidUtf8[1] = 255;
+    expect(parseRepositoryIdentityMetadata(invalidUtf8)).toBeUndefined();
+  });
+
+  it('preserves each legacy component byte ceiling including line separators', () => {
+    const base = {
+      repoRoot: '/repo',
+      commonDirectory: '/common',
+      gitDirectory: '/git',
+      objectFormat: 'sha1' as const,
+      headCommit: 'a'.repeat(40),
+    };
+    const exactRoot = {...base, repoRoot: '/' + 'r'.repeat(rootLimit - 2)};
+    expect(parseRepositoryIdentityMetadata(frame(exactRoot))).toEqual(exactRoot);
+    expect(parseRepositoryIdentityMetadata(frame({...exactRoot, repoRoot: exactRoot.repoRoot + 'r'}))).toBeUndefined();
+    const commonDirectory = '/' + '東'.repeat(2_000);
+    const gitDirectory = '/' + 'g'.repeat(directoryLimit - utf8.encode(commonDirectory).byteLength - 3);
+    const exactDirectories = {...base, commonDirectory, gitDirectory};
+    expect(parseRepositoryIdentityMetadata(frame(exactDirectories))).toEqual(exactDirectories);
+    expect(
+      parseRepositoryIdentityMetadata(frame({...exactDirectories, gitDirectory: gitDirectory + 'g'})),
+    ).toBeUndefined();
+    expect(parseRepositoryIdentityMetadata(new Uint8Array(rootLimit + directoryLimit + 129))).toBeUndefined();
+  });
+
+  effectIt.effect('matches complete legacy discovery for live, detached, unborn, nested and linked repositories', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const command = yield* CommandExecutor;
+      const temporary = yield* tempDirectory('threadnote-metadata-parity-');
+      for (const format of ['sha1', 'sha256'] as const) {
+        const root = path.join(temporary, `repo ${format}`);
+        yield* fs.makeDirectory(root);
+        yield* git(root, ['init', '-q', '--object-format=' + format, '-b', 'main']);
+        const unborn = yield* compareDiscovery(root, command);
+        expect(unborn.identity.branch).toBe('main');
+        expect(unborn.identity.headCommit).toBe('0'.repeat(format === 'sha1' ? 40 : 64));
+        yield* git(root, ['config', 'commit.gpgsign', 'false']);
+        yield* git(root, [
+          '-c',
+          'user.name=Threadnote Test',
+          '-c',
+          'user.email=test@threadnote.local',
+          'commit',
+          '--allow-empty',
+          '-qm',
+          'fixture',
+        ]);
+        yield* git(root, ['remote', 'add', 'origin', 'https://github.com/example/metadata-parity.git']);
+        yield* git(root, ['config', 'core.ignorecase', 'true']);
+        const nested = path.join(root, 'nested directory');
+        yield* fs.makeDirectory(nested);
+        const calls: Invocation[] = [];
+        const initial = yield* resolveRepositoryIdentityDetail(nested).pipe(
+          Effect.provideService(CommandExecutor, counted(command, calls)),
+        );
+        expect(calls).toHaveLength(4);
+        expect(calls[0].kind).toBe('bytes');
+        expect(calls.slice(1).every(call => call.args[1] === initial.identity.repoRoot)).toBe(true);
+        expect(initial.identity).not.toHaveProperty('gitDirectory');
+        expect(initial.identity.caseMode).toBe('insensitive');
+        expect(yield* compareDiscovery(nested, command)).toEqual(initial);
+        yield* git(root, ['checkout', '--detach', '-q']);
+        expect((yield* compareDiscovery(nested, command)).identity.branch).toBeUndefined();
+        const linked = path.join(temporary, `linked ${format}`);
+        yield* git(root, ['worktree', 'add', '-q', '-b', 'linked-' + format, linked]);
+        const linkedDetail = yield* compareDiscovery(linked, command);
+        expect(linkedDetail.gitDirectory).not.toBe(linkedDetail.identity.gitCommonDirectory);
+        expect(linkedDetail.identity.checkoutId).toBe(initial.identity.checkoutId);
+        expect(linkedDetail.identity.worktreeId).not.toBe(initial.identity.worktreeId);
+      }
+    }).pipe(provideTestLayer(platformLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('keeps successful metadata bound to its canonical root when the caller retargets', () =>
+    Effect.gen(function* () {
+      const {first, second, caller, command} = yield* routedRepositories();
+      const fs = yield* FileSystem.FileSystem;
+      const initial = yield* resolveRepositoryIdentityDetail(first);
+      const calls: Invocation[] = [];
+      const delegate = counted(command, calls);
+      const routed = CommandExecutor.of({
+        ...delegate,
+        executeBytes: (executable, args, options) =>
+          delegate.executeBytes!(executable, args, options).pipe(
+            Effect.tap(() =>
+              isBatch(args)
+                ? fs.remove(caller).pipe(Effect.orDie, Effect.andThen(directoryLink(second, caller)))
+                : Effect.void,
+            ),
+          ),
+      });
+      const observed = yield* resolveRepositoryIdentityDetail(caller).pipe(
+        Effect.provideService(CommandExecutor, routed),
+      );
+      expect(observed).toEqual(initial);
+      expect(calls).toHaveLength(4);
+      expect(calls.slice(1).every(call => call.args[1] === initial.identity.repoRoot)).toBe(true);
+    }).pipe(provideTestLayer(platformLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('discards every partial field before fresh discovery at a retargeted caller', () =>
+    Effect.gen(function* () {
+      const {first, second, caller, command} = yield* routedRepositories();
+      const fs = yield* FileSystem.FileSystem;
+      const expected = yield* resolveRepositoryIdentityDetail(second);
+      const initial = yield* resolveRepositoryIdentityDetail(first);
+      const calls: Invocation[] = [];
+      const delegate = counted(command, calls);
+      const routed = CommandExecutor.of({
+        ...delegate,
+        executeBytes: (executable, args, options) =>
+          delegate.executeBytes!(executable, args, options).pipe(
+            Effect.filterOrElse(
+              () => !isBatch(args),
+              result =>
+                fs.remove(caller).pipe(
+                  Effect.orDie,
+                  Effect.andThen(directoryLink(second, caller)),
+                  Effect.as({
+                    ...result,
+                    stdout: utf8.encode(`${initial.identity.repoRoot}\n${initial.identity.gitCommonDirectory}\n`),
+                  }),
+                ),
+            ),
+          ),
+      });
+      const observed = yield* resolveRepositoryIdentityDetail(caller).pipe(
+        Effect.provideService(CommandExecutor, routed),
+      );
+      expect(observed).toEqual(expected);
+      expect(calls).toHaveLength(8);
+      expect(calls[1]).toEqual({kind: 'text', args: ['-C', caller, 'rev-parse', '--show-toplevel']});
+      expect(calls.slice(2).every(call => call.args[1] === expected.identity.repoRoot)).toBe(true);
+    }).pipe(provideTestLayer(platformLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('does not retry infrastructure failures or exceed a configured capture bound', () =>
+    Effect.gen(function* () {
+      const command = yield* CommandExecutor;
+      const base = {args: [], executable: 'git', message: 'fixture command error'};
+      for (const failure of [
+        CommandTimedOut.make({...base, timeoutMs: 30_000}),
+        CommandOutputLimitExceeded.make({...base, maxOutputBytes: rootLimit + directoryLimit + 128}),
+        CommandSpawnFailed.make({...base, cause: new Error('fixture spawn error')}),
+      ]) {
+        let calls = 0;
+        const failing = CommandExecutor.of({
+          ...command,
+          execute: () =>
+            Effect.sync(() => {
+              calls += 1;
+            }).pipe(Effect.andThen(Effect.fail(failure))),
+          executeBytes: (_executable, _args, options) =>
+            Effect.sync(() => {
+              calls += 1;
+              expect(options?.maxOutputBytes).toBe(rootLimit + directoryLimit + 128);
+              expect(options?.timeoutMs).toBe(30_000);
+            }).pipe(Effect.andThen(Effect.fail(failure))),
+        });
+        expect(
+          yield* resolveRepositoryIdentityDetail('/unused').pipe(
+            Effect.provideService(CommandExecutor, failing),
+            Effect.flip,
+          ),
+        ).toMatchObject({
+          _tag: 'CodeGraphRepositoryError',
+          message: `Not a Git repository: ${failure.message}`,
+        });
+        expect(calls).toBe(1);
+      }
+    }).pipe(provideTestLayer(platformLayer), TestClock.withLive),
+  );
+});
+
+function frame(value: {
+  readonly repoRoot: string;
+  readonly commonDirectory: string;
+  readonly gitDirectory: string;
+  readonly objectFormat: string;
+  readonly headCommit: string;
+}) {
+  return utf8.encode(
+    [value.repoRoot, value.commonDirectory, value.gitDirectory, value.objectFormat, value.headCommit].join('\n') + '\n',
+  );
+}
+
+function isBatch(args: readonly string[]) {
+  return args.includes('--show-toplevel') && args.includes('--git-dir');
+}
+
+function counted(command: Commands, calls: Invocation[]): Commands {
+  return CommandExecutor.of({
+    ...command,
+    execute: (executable, args, options) =>
+      Effect.sync(() => {
+        calls.push({kind: 'text', args});
+      }).pipe(Effect.andThen(command.execute(executable, args, options))),
+    executeBytes: (executable, args, options) =>
+      Effect.sync(() => {
+        calls.push({kind: 'bytes', args});
+      }).pipe(Effect.andThen(command.executeBytes!(executable, args, options))),
+  });
+}
+
+const compareDiscovery = Effect.fn('repositoryMetadataBatchTest.compareDiscovery')(function* (
+  cwd: string,
+  command: Commands,
+) {
+  const actual = yield* resolveRepositoryIdentityDetail(cwd);
+  const legacy = CommandExecutor.of({
+    ...command,
+    executeBytes: (executable, args, options) =>
+      isBatch(args)
+        ? Effect.succeed({exitCode: 128, stdout: new Uint8Array(), stderr: 'force complete legacy discovery'})
+        : command.executeBytes!(executable, args, options),
+  });
+  expect(yield* resolveRepositoryIdentityDetail(cwd).pipe(Effect.provideService(CommandExecutor, legacy))).toEqual(
+    actual,
+  );
+  return actual;
+});
+
+const routedRepositories = Effect.fn('repositoryMetadataBatchTest.routedRepositories')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const command = yield* CommandExecutor;
+  const temporary = yield* tempDirectory('threadnote-metadata-routing-');
+  const first = path.join(temporary, 'first');
+  const second = path.join(temporary, 'second');
+  const caller = path.join(temporary, 'caller');
+  yield* fs.makeDirectory(first);
+  yield* git(first, ['init', '-q', '-b', 'main']);
+  yield* git(first, [
+    '-c',
+    'commit.gpgsign=false',
+    '-c',
+    'user.name=Threadnote Test',
+    '-c',
+    'user.email=test@threadnote.local',
+    'commit',
+    '--allow-empty',
+    '-qm',
+    'fixture',
+  ]);
+  yield* git(temporary, ['clone', '-q', first, second]);
+  yield* git(first, ['remote', 'add', 'origin', 'https://github.com/example/first.git']);
+  yield* git(second, ['remote', 'set-url', 'origin', 'https://github.com/example/second.git']);
+  yield* git(first, ['config', 'core.ignorecase', 'true']);
+  yield* git(second, ['config', 'core.ignorecase', 'false']);
+  yield* directoryLink(first, caller);
+  return {first, second, caller, command};
+});
+
+const tempDirectory = Effect.fn('repositoryMetadataBatchTest.tempDirectory')(function* (prefix: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireRelease(fs.makeTempDirectory({prefix}), directory =>
+    fs.remove(directory, {recursive: true, force: true}).pipe(Effect.orDie),
+  );
+});
+
+const git = Effect.fn('repositoryMetadataBatchTest.git')((cwd: string, args: readonly string[]) =>
+  runCommandEffect('git', ['-C', cwd, ...args], {maxOutputBytes: 1_048_576, timeoutMs: 30_000}),
+);
+
+function directoryLink(target: string, link: string) {
+  return Effect.sync(() => symlinkSync(target, link, 'junction'));
+}

--- a/test/unit/recall-posting-join-plans.test.ts
+++ b/test/unit/recall-posting-join-plans.test.ts
@@ -1,0 +1,369 @@
+import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {describe, expect} from 'vitest';
+import type {RecallEligibilityPolicy} from '../../src/recall/eligibility.js';
+import {postingLexicalScore} from '../../src/recall/index_lexical.js';
+import {selectRecallQueryTermStatistics, selectTopRecallPostingsByTerms} from '../../src/recall/index_selection.js';
+import type {RecallCorpusStatistics} from '../../src/recall/rank.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const withDatabase = provideTestLayer(SqliteClient.layer({filename: ':memory:'}));
+const prefix = 'threadnote://user/test/memories/allowed';
+const terms = ['alpha', 'beta', 'absent'];
+interface Document {
+  readonly id: number;
+  readonly uri: string;
+  readonly logicalKey: string;
+  readonly length: number;
+  readonly project: string | null;
+  readonly workspace: string | null;
+  readonly approved: boolean;
+  readonly terms: readonly string[];
+  readonly weight: number;
+  readonly frequency: number;
+}
+type Selection = Parameters<typeof selectRecallQueryTermStatistics>[3];
+const generatedDocument = FC.record({
+  allowed: FC.boolean(),
+  approved: FC.boolean(),
+  frequency: FC.integer({min: 1, max: 3}),
+  length: FC.integer({min: 1, max: 100}),
+  logical: FC.integer({min: 0, max: 12}),
+  project: FC.constantFrom(null, 'p', 'q'),
+  terms: FC.subarray(['alpha', 'beta']),
+  weight: FC.integer({min: 1, max: 5}),
+  workspace: FC.constantFrom(null, 'team', 'team/app', 'elsewhere'),
+});
+
+describe('scoped recall posting joins', () => {
+  effectIt.effect('filters aliases, URI boundaries and authority before logical counts and posting limits', () =>
+    Effect.gen(function* () {
+      const base = {project: 'p', workspace: null, approved: true, terms: ['alpha'], weight: 1, frequency: 1};
+      const documents: Document[] = [
+        {...base, id: 4, uri: `${prefix}/first`, logicalKey: 'shared', length: 10},
+        {...base, id: 3, uri: `${prefix}/alias`, logicalKey: 'shared', length: 20},
+        {...base, id: 2, uri: `${prefix}-elsewhere/high`, logicalKey: 'shared', length: 1_000, weight: 1_000},
+        {
+          ...base,
+          id: 1,
+          uri: `${prefix}/unapproved`,
+          logicalKey: 'other',
+          length: 1_000,
+          weight: 1_000,
+          approved: false,
+        },
+      ];
+      const sql = yield* createDocuments(documents);
+      const eligibility = {
+        kind: 'candidate-policy',
+        authority: 'approved-authoritative',
+        projects: {mode: 'unrestricted'},
+      } as const;
+      const statistics = yield* selectRecallQueryTermStatistics(sql, ['alpha'], modelStatistics(documents), {
+        allowedUriScopes: [prefix],
+        eligibility,
+        project: 'p',
+      });
+      expect(statistics).toEqual({
+        documentCount: 1,
+        totalDocumentLength: 20,
+        averageDocumentLength: 20,
+        documentFrequency: {alpha: 1},
+      });
+      const selected = yield* selectTopRecallPostingsByTerms(
+        sql,
+        ['alpha'],
+        [prefix],
+        eligibility,
+        'p',
+        undefined,
+        undefined,
+        1,
+        statistics,
+      );
+      expect(selected.map(row => row.document_id)).toEqual([4]);
+    }).pipe(withDatabase),
+  );
+
+  effectIt.effect('counts sparse URI-scoped terms by document rowid without repeated range scans', () =>
+    Effect.gen(function* () {
+      const documents: Document[] = Array.from({length: 2_000}, (_, index) => ({
+        id: 2_000 - index,
+        uri: `${prefix}/${String(index).padStart(5, '0')}`,
+        logicalKey: `logical-${index}`,
+        length: 20,
+        project: 'p',
+        workspace: null,
+        approved: true,
+        terms: index < 24 ? ['alpha'] : [],
+        weight: 1,
+        frequency: 1,
+      }));
+      const sql = yield* createDocuments(documents);
+      const {captured, observed} = observeQueries(sql);
+      const options = {allowedUriScopes: [prefix], project: 'p'};
+      const statistics = yield* selectRecallQueryTermStatistics(
+        observed,
+        ['alpha'],
+        modelStatistics(documents),
+        options,
+      );
+      expect(statistics.documentFrequency).toEqual({alpha: 24});
+      const selected = yield* selectTopRecallPostingsByTerms(
+        observed,
+        ['alpha'],
+        [prefix],
+        undefined,
+        'p',
+        undefined,
+        undefined,
+        8,
+        statistics,
+      );
+      expect(selected.map(row => row.uri)).toEqual(documents.slice(0, 8).map(row => row.uri));
+      const joins = captured.filter(query => query.text.includes('COUNT(DISTINCT d.logical_key)'));
+      expect(joins).toHaveLength(1);
+      for (const query of joins) {
+        const plan = yield* sql.unsafe<{detail: string}>(`EXPLAIN QUERY PLAN ${query.text}`, query.parameters);
+        expect(plan.some(row => /SEARCH p USING PRIMARY KEY \(term=/u.test(row.detail))).toBe(true);
+        expect(plan.some(row => row.detail.includes('SEARCH d USING INTEGER PRIMARY KEY (rowid=?)'))).toBe(true);
+        expect(plan.some(row => /(?:SCAN d|SEARCH d USING INDEX documents_uri)/u.test(row.detail))).toBe(false);
+      }
+    }).pipe(withDatabase),
+  );
+
+  effectIt.effect('retains workspace-only frequency and narrow-scope top-posting access plans', () =>
+    Effect.gen(function* () {
+      const documents: Document[] = Array.from({length: 100}, (_, index) => ({
+        id: index + 1,
+        uri: `${prefix}/${index}`,
+        logicalKey: `logical-${index}`,
+        length: 20,
+        project: 'p',
+        workspace: index === 0 ? 'team/app' : 'elsewhere',
+        approved: true,
+        terms: ['alpha'],
+        weight: 1,
+        frequency: 1,
+      }));
+      const sql = yield* createDocuments(documents);
+      const {captured, observed} = observeQueries(sql);
+      for (const allowedUriScopes of [undefined, []]) {
+        const statistics = yield* selectRecallQueryTermStatistics(observed, ['alpha'], modelStatistics(documents), {
+          allowedUriScopes,
+          workspaceScope: 'team/app',
+        });
+        expect(statistics.documentFrequency).toEqual({alpha: 1});
+      }
+      const frequencyQueries = captured.filter(query => query.text.includes('COUNT(DISTINCT d.logical_key)'));
+      expect(frequencyQueries).toHaveLength(2);
+      expect(frequencyQueries[0]).toEqual(frequencyQueries[1]);
+      for (const query of frequencyQueries) {
+        const plan = yield* sql.unsafe<{detail: string}>(`EXPLAIN QUERY PLAN ${query.text}`, query.parameters);
+        expect(plan.some(row => row.detail.includes('documents_workspace_scope_uri'))).toBe(true);
+      }
+      const selected = yield* selectTopRecallPostingsByTerms(
+        observed,
+        ['alpha'],
+        [documents[0].uri],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        modelStatistics(documents.slice(0, 1)),
+      );
+      expect(selected.map(row => row.document_id)).toEqual([1]);
+      const postingQuery = captured.find(query => query.text.startsWith('WITH query_terms'))!;
+      const plan = yield* sql.unsafe<{detail: string}>(
+        `EXPLAIN QUERY PLAN ${postingQuery.text}`,
+        postingQuery.parameters,
+      );
+      expect(plan.some(row => row.detail.includes('documents_uri'))).toBe(true);
+    }).pipe(withDatabase),
+  );
+
+  effectIt.effect.prop(
+    'matches independent scoped logical statistics and JavaScript ranking before every per-term limit',
+    {
+      rows: FC.array(generatedDocument, {minLength: 1, maxLength: 36}),
+      limit: FC.integer({min: 1, max: 8}),
+      scope: FC.constantFrom('prefix', 'exact', 'all', 'empty'),
+      project: FC.constantFrom(undefined, 'p'),
+      workspace: FC.constantFrom('all', 'hierarchy', 'sibling'),
+      policy: FC.constantFrom('any', 'approved', 'project', 'deny', 'pinned'),
+    },
+    ({rows, limit, scope, project, workspace, policy}) =>
+      Effect.gen(function* () {
+        const documents: Document[] = rows.map((row, index) => ({
+          ...row,
+          id: rows.length - index,
+          uri: `${prefix}${row.allowed ? '' : '-elsewhere'}/${String(index).padStart(4, '0')}`,
+          logicalKey: `logical-${row.logical}`,
+        }));
+        const allowedUriScopes =
+          scope === 'all'
+            ? undefined
+            : scope === 'empty'
+              ? ['   ']
+              : scope === 'exact'
+                ? [documents[0].uri]
+                : [`${prefix}/`, prefix];
+        const eligibility: RecallEligibilityPolicy | undefined =
+          policy === 'any'
+            ? undefined
+            : policy === 'pinned'
+              ? {kind: 'pinned-hard-uri-bypass'}
+              : {
+                  kind: 'candidate-policy',
+                  authority: policy === 'approved' ? 'approved-authoritative' : 'any',
+                  projects:
+                    policy === 'deny'
+                      ? {mode: 'deny-all'}
+                      : policy === 'project'
+                        ? {mode: 'allow-projects-and-projectless', projects: ['p']}
+                        : {mode: 'unrestricted'},
+                };
+        const options: Selection = {
+          allowedUriScopes,
+          eligibility,
+          project,
+          workspaceScope: workspace === 'all' ? undefined : 'team/app',
+          workspaceScopeMode: workspace === 'sibling' ? 'sibling' : 'hierarchy',
+        };
+        const eligible = documents.filter(
+          row =>
+            (scope === 'all' ||
+              (scope === 'exact'
+                ? row.uri === documents[0].uri
+                : scope === 'prefix' && row.uri.startsWith(`${prefix}/`))) &&
+            (project === undefined || row.project === project) &&
+            policy !== 'deny' &&
+            (policy !== 'approved' || row.approved) &&
+            (policy !== 'project' || row.project === null || row.project === 'p') &&
+            (workspace === 'all' ||
+              (workspace === 'hierarchy'
+                ? row.workspace === null || row.workspace === 'team' || row.workspace === 'team/app'
+                : row.workspace !== null && row.workspace !== 'team' && row.workspace !== 'team/app')),
+        );
+        const sql = yield* createDocuments(documents);
+        const before = yield* sql.unsafe('SELECT * FROM documents ORDER BY id');
+        const expectedStatistics = modelStatistics(eligible);
+        const actualStatistics = yield* selectRecallQueryTermStatistics(
+          sql,
+          terms,
+          modelStatistics(documents),
+          options,
+        );
+        expect(actualStatistics).toEqual(expectedStatistics);
+        const selected = yield* selectTopRecallPostingsByTerms(
+          sql,
+          terms,
+          allowedUriScopes,
+          eligibility,
+          project,
+          options.workspaceScope,
+          options.workspaceScopeMode,
+          limit,
+          actualStatistics,
+        );
+        const expected = terms.flatMap(term =>
+          eligible
+            .filter(row => row.terms.includes(term))
+            .map(row => ({
+              row,
+              score: postingLexicalScore(
+                {documentLength: row.length, fieldWeight: row.weight, termFrequency: row.frequency},
+                term,
+                expectedStatistics,
+              ),
+            }))
+            .sort(
+              (left, right) =>
+                right.score - left.score ||
+                right.row.weight - left.row.weight ||
+                (left.row.uri < right.row.uri ? -1 : left.row.uri > right.row.uri ? 1 : 0),
+            )
+            .slice(0, limit)
+            .map(({row}) => ({
+              term,
+              document_id: row.id,
+              document_length: row.length,
+              field_weight: row.weight,
+              term_frequency: row.frequency,
+              uri: row.uri,
+            })),
+        );
+        expect(selected).toEqual(expected);
+        expect(yield* sql.unsafe('SELECT * FROM documents ORDER BY id')).toEqual(before);
+      }).pipe(withDatabase),
+    {fastCheck: {numRuns: 75}},
+  );
+});
+
+function observeQueries(sql: SqlClient.SqlClient) {
+  const captured: Array<{text: string; parameters: readonly unknown[]}> = [];
+  const observed = new Proxy(sql, {
+    get(target, property, receiver) {
+      if (property !== 'unsafe') return Reflect.get(target, property, receiver);
+      return <A extends object>(text: string, parameters: readonly unknown[] = []) => {
+        captured.push({text, parameters});
+        return target.unsafe<A>(text, parameters);
+      };
+    },
+  });
+  return {captured, observed};
+}
+
+function modelStatistics(documents: readonly Document[]): RecallCorpusStatistics {
+  const lengths = new Map<string, number>();
+  for (const row of documents) lengths.set(row.logicalKey, Math.max(lengths.get(row.logicalKey) ?? 0, row.length));
+  const totalDocumentLength = [...lengths.values()].reduce((sum, length) => sum + length, 0);
+  const documentFrequency: Record<string, number> = {};
+  for (const term of terms) {
+    const count = new Set(documents.filter(row => row.terms.includes(term)).map(row => row.logicalKey)).size;
+    if (count > 0) documentFrequency[term] = count;
+  }
+  return {
+    documentCount: lengths.size,
+    totalDocumentLength,
+    averageDocumentLength: lengths.size === 0 ? 1 : totalDocumentLength / lengths.size,
+    documentFrequency,
+  };
+}
+
+const createDocuments = Effect.fn('test.createRecallJoinDocuments')(function* (documents: readonly Document[]) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* sql.unsafe(`CREATE TABLE documents (id INTEGER PRIMARY KEY, uri TEXT NOT NULL,
+    logical_key TEXT NOT NULL, document_length INTEGER NOT NULL, project TEXT,
+    approved_authoritative INTEGER NOT NULL, workspace_scope TEXT)`);
+  yield* sql.unsafe(`CREATE TABLE postings (term TEXT NOT NULL, document_id INTEGER NOT NULL,
+    field_weight REAL NOT NULL, term_frequency INTEGER NOT NULL, PRIMARY KEY(term, document_id)) WITHOUT ROWID`);
+  yield* sql.unsafe('CREATE INDEX documents_uri ON documents(uri)');
+  yield* sql.unsafe('CREATE INDEX documents_workspace_scope_uri ON documents(workspace_scope, uri)');
+  yield* sql.unsafe('CREATE INDEX postings_document_id ON postings(document_id)');
+  yield* sql.withTransaction(
+    Effect.forEach(
+      documents,
+      row =>
+        Effect.gen(function* () {
+          yield* sql.unsafe('INSERT INTO documents VALUES (?, ?, ?, ?, ?, ?, ?)', [
+            row.id,
+            row.uri,
+            row.logicalKey,
+            row.length,
+            row.project,
+            row.approved ? 1 : 0,
+            row.workspace,
+          ]);
+          for (const term of row.terms)
+            yield* sql.unsafe('INSERT INTO postings VALUES (?, ?, ?, ?)', [term, row.id, row.weight, row.frequency]);
+        }),
+      {discard: true},
+    ),
+  );
+  return sql;
+});


### PR DESCRIPTION
URI-scoped recall term statistics forced SQLite to rescan the authorized URI range for each matching posting. Initial repository identity discovery also used separate Git metadata processes. Together these add avoidable work to Context Brief retrieval and validation.

Allow document rowid lookup for URI-restricted document-frequency joins, retaining authorization predicates, logical-document deduplication, corpus statistics, and existing workspace-only and top-posting access plans. Batch initial repository root, administrative directories, object format, and HEAD into one bounded fresh Git observation. Invalid or unsuccessful frames trigger complete legacy discovery at the original caller; infrastructure failures, canonical-root routing, status observations, and final validation fences retain their existing behavior.

Validation:

- Focused recall/index regression checks passed, including four new query-plan and authorization tests with a 75-case independent scope/order/non-mutation property.
- 108 focused repository identity, provenance, query and citation tests passed; the metadata parser adds a 100-case UTF-8 frame round-trip property and real-Git fallback/routing cases.
- All five shared-view attachment integration cases passed, retaining builder-lock, capacity and repository-race assertions with the updated command instrumentation.
- Both independent reviews and the combined full precommit checks passed.
- The exact reviewed runtime commit `c183265f` passed global installation, doctor verification and superseded-process cleanup. Installed CLI checks passed for scoped lexical recall (scope/archive exclusions, bounded results, cold/warm equality) and first-brief deferred-link recovery. The follow-up commit changes only two instrumentation-test lines.
- Installed repository identity smoke passed eight real-Git cases: SHA-1 and SHA-256 repositories, each unborn, nested committed, detached, and linked. Initial discovery used one metadata batch at the original caller in every case and complete legacy discovery only for unborn HEADs; canonical-root validation observations remain separate.
- One matched local 100,000-memory diagnostic (20 measured, 2 warmups) reduced mean total time from 481.776 to 295.183 ms and recall from 395.783 to 209.557 ms. Selected results, receipt/currentness checks, two status observations, one store session, and balanced leases were unchanged. Validation mean stayed essentially flat (82.778 to 82.563 ms). These are local diagnostics; fresh release qualification is still required on the final main commit.

Full PR CI must pass before merge. No performance budgets, fixture definitions, cache contracts, or release qualification rules change.
