### PR TITLE
Finalize uncached SQLite statements after each operation

### DIFF
--- a/patches/@effect%2Fsql-sqlite-bun@4.0.0-rc.112.patch
+++ b/patches/@effect%2Fsql-sqlite-bun@4.0.0-rc.112.patch
@@ -1,8 +1,88 @@
 diff --git a/dist/SqliteClient.js b/dist/SqliteClient.js
-index bef1706779e0af97ab4f409d17e8b9e056beea64..27d84a5abd4dd2681286c37010e39c2a40ce6d78 100644
+index bef1706779e0af97ab4f409d17e8b9e056beea64..30f23f675233655e9af2f16d80fa432f66b460bb 100644
 --- a/dist/SqliteClient.js
 +++ b/dist/SqliteClient.js
-@@ -145,7 +145,7 @@ export const make = options => Effect.gen(function* () {
+@@ -68,22 +68,64 @@ export const make = options => Effect.gen(function* () {
+       readwrite: readonly ? false : options.readwrite ?? true,
+       create: readonly ? false : options.create ?? true
+     });
+-    yield* Effect.addFinalizer(() => Effect.sync(() => db.close()));
++    const cachedStatements = new Map();
++    yield* Effect.addFinalizer(() => Effect.sync(() => {
++      let failed = false;
++      let failure;
++      for (const statement of cachedStatements.values()) {
++        try {
++          statement.finalize();
++        } catch (cause) {
++          if (!failed) {
++            failed = true;
++            failure = cause;
++          }
++        }
++      }
++      cachedStatements.clear();
++      try {
++        db.close();
++      } catch (cause) {
++        if (!failed) {
++          failed = true;
++          failure = cause;
++        }
++      }
++      if (failed) throw failure;
++    }));
+     const busyTimeout = Math.min(MAX_BUSY_TIMEOUT, Math.max(0, Math.round(Duration.toMillis(options.busyTimeout ?? Duration.seconds(5)))));
+     db.run(`PRAGMA busy_timeout = ${busyTimeout};`);
+     if (options.disableWAL !== true && !readonly) {
+       db.run("PRAGMA journal_mode = WAL;");
+     }
+-    const prepare = (sql, useSafeIntegers) => {
++    const runStatement = (sql, useSafeIntegers, params, values) => {
+       const statement = db.query(sql);
+-      // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
+-      statement.safeIntegers(useSafeIntegers);
+-      return statement;
++      // Keep Bun's first-20 exact-query reuse and own every other statement
++      // only for its synchronous execution. No native cache internals are read.
++      const cached = cachedStatements.has(sql) || cachedStatements.size < 20;
++      if (cached) cachedStatements.set(sql, statement);
++      let completed = false;
++      try {
++        // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
++        statement.safeIntegers(useSafeIntegers);
++        const rows = values ? statement.values(...params) : statement.all(...params);
++        completed = true;
++        return rows ?? [];
++      } finally {
++        if (!cached) {
++          try {
++            statement.finalize();
++          } catch (cause) {
++            // Preserve an execution/setup failure; otherwise surface cleanup failure.
++            if (completed) throw cause;
++          }
++        }
++      }
+     };
+     const run = (sql, params = []) => Effect.withFiber(fiber => {
+       const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers);
+       try {
+-        return Effect.succeed(prepare(sql, useSafeIntegers).all(...params) ?? []);
++        return Effect.succeed(runStatement(sql, useSafeIntegers, params, false));
+       } catch (cause) {
+         return Effect.fail(new SqlError({
+           reason: classifyError(cause, "Failed to execute statement", "execute")
+@@ -93,7 +135,7 @@ export const make = options => Effect.gen(function* () {
+     const runValues = (sql, params = []) => Effect.withFiber(fiber => {
+       const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers);
+       try {
+-        return Effect.succeed(prepare(sql, useSafeIntegers).values(...params) ?? []);
++        return Effect.succeed(runStatement(sql, useSafeIntegers, params, true));
+       } catch (cause) {
+         return Effect.fail(new SqlError({
+           reason: classifyError(cause, "Failed to execute statement", "executeValues")
+@@ -145,7 +187,7 @@ export const make = options => Effect.gen(function* () {
      acquirer,
      compiler,
      transactionAcquirer,
@@ -12,10 +92,100 @@ index bef1706779e0af97ab4f409d17e8b9e056beea64..27d84a5abd4dd2681286c37010e39c2a
      transformRows
    }), {
 diff --git a/src/SqliteClient.ts b/src/SqliteClient.ts
-index e54047a1122db25933d1f31d0a41c7cf09287c49..5bf79cf872b64539aa57402f20a528f0e249b5fb 100644
+index e54047a1122db25933d1f31d0a41c7cf09287c49..e89fd2daa379c9f63c6e70f672f5c7f6837e708d 100644
 --- a/src/SqliteClient.ts
 +++ b/src/SqliteClient.ts
-@@ -235,7 +235,7 @@ export const make = (
+@@ -134,7 +134,31 @@ export const make = (
+         readwrite: readonly ? false : options.readwrite ?? true,
+         create: readonly ? false : options.create ?? true
+       } as any)
+-      yield* Effect.addFinalizer(() => Effect.sync(() => db.close()))
++      const cachedStatements = new Map<string, ReturnType<Database["query"]>>()
++      yield* Effect.addFinalizer(() => Effect.sync(() => {
++        let failed = false
++        let failure: unknown
++        for (const statement of cachedStatements.values()) {
++          try {
++            statement.finalize()
++          } catch (cause) {
++            if (!failed) {
++              failed = true
++              failure = cause
++            }
++          }
++        }
++        cachedStatements.clear()
++        try {
++          db.close()
++        } catch (cause) {
++          if (!failed) {
++            failed = true
++            failure = cause
++          }
++        }
++        if (failed) throw failure
++      }))
+       const busyTimeout = Math.min(
+         MAX_BUSY_TIMEOUT,
+         Math.max(0, Math.round(Duration.toMillis(options.busyTimeout ?? Duration.seconds(5))))
+@@ -145,11 +169,34 @@ export const make = (
+         db.run("PRAGMA journal_mode = WAL;")
+       }
+ 
+-      const prepare = (sql: string, useSafeIntegers: boolean) => {
++      const runStatement = (
++        sql: string,
++        useSafeIntegers: boolean,
++        params: ReadonlyArray<unknown>,
++        values: boolean
++      ): Array<any> => {
+         const statement = db.query(sql)
+-        // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
+-        statement.safeIntegers(useSafeIntegers)
+-        return statement
++        // Keep Bun's first-20 exact-query reuse and own every other statement
++        // only for its synchronous execution. No native cache internals are read.
++        const cached = cachedStatements.has(sql) || cachedStatements.size < 20
++        if (cached) cachedStatements.set(sql, statement)
++        let completed = false
++        try {
++          // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
++          statement.safeIntegers(useSafeIntegers)
++          const rows = values ? statement.values(...(params as any)) : statement.all(...(params as any))
++          completed = true
++          return (rows ?? []) as Array<any>
++        } finally {
++          if (!cached) {
++            try {
++              statement.finalize()
++            } catch (cause) {
++              // Preserve an execution/setup failure; otherwise surface cleanup failure.
++              if (completed) throw cause
++            }
++          }
++        }
+       }
+ 
+       const run = (
+@@ -159,7 +206,7 @@ export const make = (
+         Effect.withFiber<Array<any>, SqlError>((fiber) => {
+           const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
+           try {
+-            return Effect.succeed((prepare(sql, useSafeIntegers).all(...(params as any)) ?? []) as Array<any>)
++            return Effect.succeed(runStatement(sql, useSafeIntegers, params, false))
+           } catch (cause) {
+             return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
+           }
+@@ -172,7 +219,7 @@ export const make = (
+         Effect.withFiber<Array<any>, SqlError>((fiber) => {
+           const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
+           try {
+-            return Effect.succeed((prepare(sql, useSafeIntegers).values(...(params as any)) ?? []) as Array<any>)
++            return Effect.succeed(runStatement(sql, useSafeIntegers, params, true))
+           } catch (cause) {
+             return Effect.fail(
+               new SqlError({ reason: classifyError(cause, "Failed to execute statement", "executeValues") })
+@@ -235,7 +282,7 @@ export const make = (
          acquirer,
          compiler,
          transactionAcquirer,

--- a/test/helpers/sqlite-native-statements.ts
+++ b/test/helpers/sqlite-native-statements.ts
@@ -1,0 +1,56 @@
+import {Database} from 'bun:sqlite';
+import {Effect} from 'effect';
+import {vi} from 'vitest';
+
+type NativeStatement = ReturnType<Database['query']> & {
+  readonly isFinalized: boolean;
+  safeIntegers(enabled: boolean): NativeStatement;
+};
+
+export interface ObservedNativeStatement {
+  readonly sql: string;
+  readonly statement: NativeStatement;
+  readonly finalize: () => void;
+}
+
+/** Hold wrappers deliberately: collection must not make disposal assertions pass. */
+export const observeNativeStatements = Effect.fn('test.observeNativeStatements')(function* (
+  onPrepare?: (entry: ObservedNativeStatement) => void,
+) {
+  return yield* Effect.acquireRelease(
+    Effect.sync(() => {
+      const entries: ObservedNativeStatement[] = [];
+      const databases = new Set<Database>();
+      const originalPrepare = Database.prototype.prepare;
+      const originalClose = Database.prototype.close;
+      const observation = {closeAttempts: 0, entries, strictCloses: 0};
+      const prepare = vi.spyOn(Database.prototype, 'prepare').mockImplementation(function (
+        this: Database,
+        ...args: Parameters<Database['prepare']>
+      ) {
+        databases.add(this);
+        const statement = Reflect.apply(originalPrepare, this, args) as NativeStatement;
+        const finalize = statement.finalize.bind(statement);
+        const entry = {finalize, sql: args[0], statement};
+        entries.push(entry);
+        onPrepare?.(entry);
+        return statement;
+      });
+      const close = vi.spyOn(Database.prototype, 'close').mockImplementation(function (this: Database) {
+        databases.add(this);
+        observation.closeAttempts++;
+        // Strict native close fails while any unfinalized statement is alive.
+        originalClose.call(this, true);
+        observation.strictCloses++;
+      });
+      return {databases, observation, originalClose, prepare, close};
+    }),
+    ({databases, observation, originalClose, prepare, close}) =>
+      Effect.sync(() => {
+        prepare.mockRestore();
+        close.mockRestore();
+        for (const entry of observation.entries) entry.finalize();
+        for (const database of databases) originalClose.call(database, true);
+      }),
+  ).pipe(Effect.map(value => value.observation));
+});

--- a/test/unit/code-graph.maintenance-bounded.test.ts
+++ b/test/unit/code-graph.maintenance-bounded.test.ts
@@ -851,34 +851,53 @@ describe('bounded code graph maintenance', () => {
       yield* store.initialize(databasePath);
       yield* Effect.sync(() => makePreReconciliationIndexRevision7(databasePath));
 
-      const schemaBeforePreview = yield* Effect.sync(() => readReconciliationPreparationState(databasePath));
-      const filesBeforePreview = yield* Effect.promise(() => readDatabaseDurabilityEvidence(databasePath));
-      const repeated = yield* Effect.forEach(
-        [1, 2, 3, 4, 5],
-        () => store.prepareWorktreeReconciliationIndexes(databasePath, {preview: true}),
-        {concurrency: 1},
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => new Database(databasePath, {strict: true})),
+        keeper =>
+          Effect.gen(function* () {
+            // Keep committed WAL content present while preview connections close; a final writer close may
+            // otherwise remove an empty sidecar without changing the database or committing the preview.
+            yield* Effect.sync(() => {
+              keeper.run('PRAGMA wal_autocheckpoint = 0');
+              keeper
+                .query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)')
+                .run('reconciliation_preview_fixture', 'committed-before-preview');
+              expect(keeper.inTransaction).toBe(false);
+            });
+            const schemaBeforePreview = yield* Effect.sync(() => readReconciliationPreparationState(databasePath));
+            const filesBeforePreview = yield* Effect.promise(() => readDatabaseDurabilityEvidence(databasePath));
+            expect('bytes' in filesBeforePreview.wal && filesBeforePreview.wal.bytes > 32).toBe(true);
+            const repeated = yield* Effect.forEach(
+              [1, 2, 3, 4, 5],
+              () => store.prepareWorktreeReconciliationIndexes(databasePath, {preview: true}),
+              {concurrency: 1},
+            );
+            expect(repeated).toEqual(repeated.map(() => ({state: 'migration-ready'})));
+            const typedFailure = yield* store
+              .prepareWorktreeReconciliationIndexes(databasePath, {
+                afterPreviewTransactionStarted: () => Effect.fail(TestError.make({message: 'stop preview'})),
+                preview: true,
+              })
+              .pipe(Effect.exit);
+            expect(Exit.isFailure(typedFailure)).toBe(true);
+            const previewStarted = yield* Deferred.make<void>();
+            const interruptedPreview = yield* Effect.forkChild(
+              store.prepareWorktreeReconciliationIndexes(databasePath, {
+                afterPreviewTransactionStarted: () =>
+                  Deferred.succeed(previewStarted, undefined).pipe(Effect.andThen(Effect.never)),
+                preview: true,
+              }),
+            );
+            yield* Deferred.await(previewStarted);
+            yield* Fiber.interrupt(interruptedPreview);
+            const filesAfterPreview = yield* Effect.promise(() => readDatabaseDurabilityEvidence(databasePath));
+            expect(filesAfterPreview).toEqual(filesBeforePreview);
+            expect(yield* Effect.sync(() => readReconciliationPreparationState(databasePath))).toEqual(
+              schemaBeforePreview,
+            );
+          }),
+        keeper => Effect.sync(() => keeper.close(true)),
       );
-      expect(repeated).toEqual(repeated.map(() => ({state: 'migration-ready'})));
-      const typedFailure = yield* store
-        .prepareWorktreeReconciliationIndexes(databasePath, {
-          afterPreviewTransactionStarted: () => Effect.fail(TestError.make({message: 'stop preview'})),
-          preview: true,
-        })
-        .pipe(Effect.exit);
-      expect(Exit.isFailure(typedFailure)).toBe(true);
-      const previewStarted = yield* Deferred.make<void>();
-      const interruptedPreview = yield* Effect.forkChild(
-        store.prepareWorktreeReconciliationIndexes(databasePath, {
-          afterPreviewTransactionStarted: () =>
-            Deferred.succeed(previewStarted, undefined).pipe(Effect.andThen(Effect.never)),
-          preview: true,
-        }),
-      );
-      yield* Deferred.await(previewStarted);
-      yield* Fiber.interrupt(interruptedPreview);
-      const filesAfterPreview = yield* Effect.promise(() => readDatabaseDurabilityEvidence(databasePath));
-      expect(filesAfterPreview).toEqual(filesBeforePreview);
-      expect(yield* Effect.sync(() => readReconciliationPreparationState(databasePath))).toEqual(schemaBeforePreview);
 
       const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
         migrateSchema: true,

--- a/test/unit/effect-sqlite-bun-statement-lifetime.test.ts
+++ b/test/unit/effect-sqlite-bun-statement-lifetime.test.ts
@@ -1,0 +1,258 @@
+import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
+import {it as effectIt} from '@effect/vitest';
+import {Cause, Deferred, Effect, Exit, Fiber} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {describe, expect} from 'vitest';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {observeNativeStatements} from '../helpers/sqlite-native-statements.js';
+
+const layer = () => SqliteClient.layer({filename: ':memory:', disableWAL: true});
+const query = (key: number) => `SELECT ? AS value /* statement-${key} */`;
+
+describe('Effect Bun SQLite native statement lifetime', () => {
+  effectIt.effect('disposes uncached statements before GC while retaining the first twenty native cache entries', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeNativeStatements();
+      yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        for (let key = 0; key < 100; key++) {
+          expect(yield* sql.unsafe(query(key), [key])).toEqual([{value: key}]);
+          expect(observed.entries.filter(entry => !entry.statement.isFinalized)).toHaveLength(Math.min(key + 1, 20));
+          if (key >= 20) expect(observed.entries.at(-1)?.statement.isFinalized).toBe(true);
+        }
+        const preparations = observed.entries.length;
+        expect(yield* sql.unsafe(query(0), [101])).toEqual([{value: 101}]);
+        expect(observed.entries).toHaveLength(preparations);
+        expect(observed.entries.slice(0, 20).every(entry => !entry.statement.isFinalized)).toBe(true);
+      }).pipe(provideTestLayer(layer()));
+      expect(observed.entries).toHaveLength(100);
+      expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+      expect(observed.strictCloses).toBe(1);
+    }),
+  );
+
+  effectIt.effect(
+    'keeps exact SQL keys, excludes failed preparations and refreshes manually finalized cache entries',
+    () =>
+      Effect.gen(function* () {
+        const observed = yield* observeNativeStatements();
+        yield* Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          for (const invalid of ['', ' ', 'SELECT FROM']) {
+            const failure = yield* Effect.exit(sql.unsafe(invalid));
+            expect(Exit.isFailure(failure)).toBe(true);
+          }
+          expect(observed.entries).toHaveLength(0);
+          for (let key = 0; key < 20; key++) {
+            expect(yield* sql.unsafe(`SELECT 1 AS value${' '.repeat(key)}`)).toEqual([{value: 1}]);
+          }
+          expect(observed.entries.filter(entry => !entry.statement.isFinalized)).toHaveLength(20);
+          const first = observed.entries[0];
+          yield* Effect.sync(first.finalize);
+          expect(yield* sql.unsafe('SELECT 1 AS value')).toEqual([{value: 1}]);
+          expect(observed.entries).toHaveLength(21);
+          expect(Object.is(observed.entries.at(-1)?.statement, first.statement)).toBe(false);
+          expect(observed.entries.at(-1)?.statement.isFinalized).toBe(false);
+          expect(yield* sql.unsafe(query(21), [21])).toEqual([{value: 21}]);
+          expect(observed.entries.at(-1)?.statement.isFinalized).toBe(true);
+        }).pipe(provideTestLayer(layer()));
+        expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+        expect(observed.strictCloses).toBe(1);
+      }),
+  );
+
+  effectIt.effect(
+    'owns statements before integer setup and preserves the primary error if temporary cleanup fails',
+    () =>
+      Effect.gen(function* () {
+        const setupFailure = new Error('fixture integer setup failure');
+        const cleanupFailure = new Error('fixture cleanup failure');
+        const observed = yield* observeNativeStatements(entry => {
+          if (entry.sql.includes('setup-failure')) {
+            entry.statement.safeIntegers = () => {
+              throw setupFailure;
+            };
+          }
+          if (entry.sql.includes('cleanup-failure')) {
+            entry.statement.finalize = () => {
+              entry.finalize();
+              throw cleanupFailure;
+            };
+          }
+        });
+        yield* Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const first = yield* Effect.flip(sql.unsafe('SELECT 0 /* setup-failure */'));
+          expect(first.reason.cause).toBe(setupFailure);
+          expect(observed.entries[0]?.statement.isFinalized).toBe(false);
+          for (let key = 0; key < 19; key++) yield* sql.unsafe(query(key), [key]);
+          for (const values of [false, true]) {
+            const statement = sql.unsafe(`SELECT 1 /* setup-failure cleanup-failure ${values} */`);
+            const failure = yield* Effect.flip(values ? statement.values : statement);
+            expect(failure.reason.cause).toBe(setupFailure);
+            expect(observed.entries.at(-1)?.statement.isFinalized).toBe(true);
+          }
+          const cleanupOnly = yield* Effect.flip(sql.unsafe('SELECT 1 /* cleanup-failure */'));
+          expect(cleanupOnly.reason.cause).toBe(cleanupFailure);
+          expect(observed.entries.at(-1)?.statement.isFinalized).toBe(true);
+        }).pipe(provideTestLayer(layer()));
+        expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+        expect(observed.strictCloses).toBe(1);
+      }),
+  );
+
+  effectIt.effect(
+    'attempts every retained finalizer and database close while preserving the first cleanup failure',
+    () =>
+      Effect.gen(function* () {
+        const failure = new Error('fixture cached finalizer failure');
+        let injected = false;
+        const observed = yield* observeNativeStatements(entry => {
+          if (entry.sql !== query(0)) return;
+          entry.statement.finalize = () => {
+            entry.finalize();
+            if (!injected) {
+              injected = true;
+              throw failure;
+            }
+          };
+        });
+        const result = yield* Effect.exit(
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            for (let key = 0; key < 20; key++) yield* sql.unsafe(query(key), [key]);
+          }).pipe(provideTestLayer(layer())),
+        );
+        expect(Exit.isFailure(result)).toBe(true);
+        if (Exit.isFailure(result)) expect(Cause.squash(result.cause)).toBe(failure);
+        expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+        expect(observed.closeAttempts).toBe(1);
+        expect(observed.strictCloses).toBe(1);
+      }),
+  );
+
+  effectIt.effect('preserves nested rollback, constraint failures and scope cleanup after interruption', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeNativeStatements();
+      const ready = yield* Deferred.make<void>();
+      const fiber = yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql.unsafe('CREATE TABLE entries(value INTEGER PRIMARY KEY)');
+        for (let key = 0; key < 21; key++) yield* sql.unsafe(query(key), [key]);
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql.unsafe('INSERT INTO entries VALUES (1)');
+            const inner = yield* Effect.exit(
+              sql.withTransaction(
+                Effect.gen(function* () {
+                  yield* sql.unsafe('INSERT INTO entries VALUES (2)');
+                  yield* sql.unsafe('INSERT INTO entries VALUES (1)');
+                }),
+              ),
+            );
+            expect(Exit.isFailure(inner)).toBe(true);
+            expect(yield* sql.unsafe('SELECT value FROM entries ORDER BY value')).toEqual([{value: 1}]);
+          }),
+        );
+        expect(yield* sql.unsafe('SELECT value FROM entries')).toEqual([{value: 1}]);
+        return yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql.unsafe('INSERT INTO entries VALUES (3)');
+            yield* Deferred.succeed(ready, undefined);
+            return yield* Effect.never;
+          }),
+        );
+      }).pipe(provideTestLayer(layer()), Effect.forkChild);
+      yield* Deferred.await(ready);
+      yield* Fiber.interrupt(fiber);
+      expect(observed.entries.some(entry => entry.sql === 'ROLLBACK')).toBe(true);
+      expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+      expect(observed.strictCloses).toBe(1);
+    }),
+  );
+
+  effectIt.effect('preserves transformed rows and blob values after temporary disposal and connection close', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeNativeStatements();
+      const large = (1n << 60n) + 123n;
+      const bytes = Uint8Array.from([0, 1, 127, 128, 255]);
+      const results = yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const text = 'SELECT ? AS value, ? AS bytes';
+        for (const safe of [true, false, true]) {
+          expect(
+            yield* sql.unsafe(text, [large, bytes]).pipe(Effect.provideService(SqlClient.SafeIntegers, safe)),
+          ).toEqual([{VALUE: safe ? large : Number(large), BYTES: bytes}]);
+        }
+        expect(observed.entries).toHaveLength(1);
+        for (let key = 1; key < 20; key++) yield* sql.unsafe(query(key), [key]);
+        const rows = yield* sql.unsafe(text + ' /* temporary rows */', [large, bytes]);
+        const values = yield* sql.unsafe(text + ' /* temporary values */', [large, bytes]).values;
+        const raw = yield* sql.withoutTransforms().unsafe(text + ' /* temporary raw */', [large, bytes]);
+        expect(observed.entries.slice(-3).every(entry => entry.statement.isFinalized)).toBe(true);
+        return {rows, values, raw};
+      }).pipe(
+        provideTestLayer(
+          SqliteClient.layer({
+            filename: ':memory:',
+            disableWAL: true,
+            transformResultNames: name => name.toUpperCase(),
+          }),
+        ),
+      );
+      expect(results).toEqual({
+        rows: [{VALUE: Number(large), BYTES: bytes}],
+        values: [[Number(large), bytes]],
+        raw: [{value: Number(large), bytes}],
+      });
+      expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+      expect(observed.strictCloses).toBe(1);
+    }),
+  );
+
+  effectIt.effect.prop(
+    'matches independent values and native lifetime bounds across query reuse, integer modes and retained blobs',
+    {
+      operations: FC.array(
+        FC.record({
+          bytes: FC.uint8Array({maxLength: 16}),
+          key: FC.integer({min: 0, max: 31}),
+          mode: FC.constantFrom('rows', 'values', 'raw', 'unprepared', 'valuesUnprepared'),
+          safe: FC.boolean(),
+          value: FC.bigInt({min: -(1n << 60n), max: 1n << 60n}),
+        }),
+        {minLength: 24, maxLength: 48},
+      ),
+    },
+    ({operations}) =>
+      Effect.gen(function* () {
+        const observed = yield* observeNativeStatements();
+        const retained: Array<{actual: unknown; expected: unknown}> = [];
+        yield* Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          for (let key = 0; key < 20; key++) {
+            yield* sql.unsafe(`SELECT ? AS value, ? AS bytes /* property-${key} */`, [key, new Uint8Array()]);
+          }
+          for (const operation of operations) {
+            const statement = sql.unsafe(`SELECT ? AS value, ? AS bytes /* property-${operation.key} */`, [
+              operation.value,
+              operation.bytes,
+            ]);
+            const effect = operation.mode === 'rows' ? statement : statement[operation.mode];
+            const actual = yield* effect.pipe(Effect.provideService(SqlClient.SafeIntegers, operation.safe));
+            const value = operation.safe ? operation.value : Number(operation.value);
+            const bytes = Uint8Array.from(operation.bytes);
+            const expected = operation.mode.startsWith('values') ? [[value, bytes]] : [{value, bytes}];
+            expect(actual).toEqual(expected);
+            retained.push({actual, expected});
+            expect(observed.entries.filter(entry => !entry.statement.isFinalized)).toHaveLength(20);
+          }
+        }).pipe(provideTestLayer(layer()));
+        for (const {actual, expected} of retained) expect(actual).toEqual(expected);
+        expect(observed.entries.every(entry => entry.statement.isFinalized)).toBe(true);
+        expect(observed.strictCloses).toBe(1);
+      }),
+    {fastCheck: {numRuns: 30}},
+  );
+});


### PR DESCRIPTION
When a SQLite connection prepares more than 20 distinct statements, Bun leaves additional statements outside its query cache. The Effect driver previously left their native disposal to garbage collection after materializing results. A regression test holding native references demonstrates the gap: the original driver retains 21 live statements after query 21 and cannot close the database in strict mode.

Extend the pinned Effect SQLite patch to finalize uncached statements after synchronous execution and finalize the 20 owned cached statements when the connection scope closes. Every operation still calls public `db.query`, preserving exact SQL keys, native cache behavior and cached-statement reprepare. Cleanup preserves the original execution error, attempts every owned finalizer and database close, and leaves transaction behavior unchanged.

Validation: the original 17 focused tests and 28 tests across the full maintenance and native-lifetime files pass, including a 30-run property covering returned values and bounded native ownership; concrete cases cover integer and BLOB materialization, cache reuse, cleanup failures, rollback and interruption. The original-driver control fails the new lifetime regression as expected. The maintenance preview fixture now holds a scoped connection and asserts a committed nonempty WAL before checking exact database/WAL bytes across repeated previews, failure and interruption; this avoids dependence on platform-specific cleanup of an empty sidecar. Source, test and website typechecks and full lint pass.

The exact-head global install, doctor verification, superseded-runtime cleanup and Memory Connections and scoped-recall CLI smokes pass. The isolated four-memory recall flow initializes more than 20 distinct statements in one scoped connection, exercising the temporary-statement path; the held-wrapper regression supplies direct disposal proof. The runtime patch’s full local diagnostic at d4ff8a1f retained 100,000 memories across all three profiles with 100 measurements and five warmups: every substantive correctness, latency and memory budget passed. It remains development-smoke evidence. This fixes the demonstrated synchronous disposal gap; the local comparison does not establish an RSS improvement. Fresh final-main release qualification is required after PR CI and merge.
