### PR TITLE
Avoid unnecessary validation on graph reads

### DIFF
--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -532,12 +532,16 @@ export class CodeGraphQueryService extends Context.Service<
                   : statusObservation?.borrowedSnapshotId
                     ? yield* store.readySnapshotById(layout.databasePath, statusObservation.borrowedSnapshotId)
                     : yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
-              const runtimeCurrent = existing
-                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks, {
-                    layout,
-                    identity,
-                  })
-                : false;
+              const freshnessRequired =
+                options.refresh === true || options.operation === 'impact' || options.operation === 'path';
+              // This probe only decides refresh; inspectReadyGraph always validates the selected snapshot.
+              const runtimeCurrent =
+                existing && freshnessRequired
+                  ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks, {
+                      layout,
+                      identity,
+                    })
+                  : false;
               const strictFreshness =
                 options.strictFreshness ??
                 (options.refresh === true || options.operation === 'impact' || options.operation === 'path');
@@ -565,8 +569,6 @@ export class CodeGraphQueryService extends Context.Service<
                 !runtimeCurrent ||
                 existing.commit !== identity.headCommit ||
                 (overlay !== undefined && !snapshotMatches(existing, identity.headCommit, overlay));
-              const freshnessRequired =
-                options.refresh === true || options.operation === 'impact' || options.operation === 'path';
               let rebuilt = false;
               if (options.refresh !== false && (!existing || (stale && freshnessRequired))) {
                 yield* indexer.index({

--- a/src/code_graph/store_leases.ts
+++ b/src/code_graph/store_leases.ts
@@ -572,7 +572,6 @@ const releaseSnapshotLease = Effect.fn('codeGraph.releaseSnapshotLease')(functio
       if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql, false, false))) {
         return yield* CodeGraphStoreError.of('Code graph snapshot lease authority schema is invalid.');
       }
-      const retirementAuthorityCurrent = yield* codeGraphWorktreeReconciliationSchemaCompatible(sql);
       const now = yield* Clock.currentTimeMillis;
       const releasedRows = yield* sql.unsafe<BoundedSnapshotLeaseRow>(
         `SELECT ${boundedSnapshotLeaseProjection('lease')}
@@ -602,7 +601,10 @@ const releaseSnapshotLease = Effect.fn('codeGraph.releaseSnapshotLease')(functio
           return yield* CodeGraphStoreError.of('Code graph snapshot lease manifest is invalid.');
         }
         if (successor === undefined) {
-          if (retirementAuthorityCurrent) releasedCandidates.push(row.snapshotId);
+          // Ordinary readers and baton transfers do not retire this snapshot.
+          // Observe full retirement authority only when its result is needed,
+          // inside the same transaction and before admitting any retirement.
+          if (yield* codeGraphWorktreeReconciliationSchemaCompatible(sql)) releasedCandidates.push(row.snapshotId);
         } else {
           yield* sql`
             UPDATE snapshot_leases

--- a/test/unit/code-graph.lease-retirement-authority.test.ts
+++ b/test/unit/code-graph.lease-retirement-authority.test.ts
@@ -1,0 +1,233 @@
+import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
+import {it as effectIt} from '@effect/vitest';
+import {Database} from 'bun:sqlite';
+import {Clock, Effect} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {describe, expect, vi} from 'vitest';
+import {releaseSnapshotLease} from '../../src/code_graph/store_leases.js';
+import {initializeSchema} from '../../src/code_graph/store_schema_initialization.js';
+import {CODE_GRAPH_EXTRACTOR_GENERATION} from '../../src/code_graph/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const SNAPSHOT = 'cgsn_1111111111111111111111111111111111111111';
+const EXPIRED_SNAPSHOT = 'cgsn_2222222222222222222222222222222222222222';
+const WORKTREE = 'c'.repeat(64);
+const cleanupObservation = (query: string) => query.includes("pragma_table_xinfo('removed_view_cleanup')");
+
+describe('snapshot lease retirement authority', () => {
+  effectIt.effect('skips unused full retirement observations for clean and already released leases', () =>
+    withFixture(sql =>
+      Effect.gen(function* () {
+        yield* seedLease(sql, 'clean', SNAPSHOT, false);
+        const queries = yield* observeQueries();
+        expect(yield* releaseSnapshotLease('clean')).toBe(false);
+        expect(queries.filter(cleanupObservation)).toHaveLength(0);
+        expect(queries.some(query => query.includes("pragma_table_xinfo('snapshot_leases')"))).toBe(true);
+        expect(queries.some(query => query.includes('WHERE lease.expires_at <= ?'))).toBe(true);
+        queries.length = 0;
+        expect(yield* releaseSnapshotLease('clean')).toBe(false);
+        expect(queries.filter(cleanupObservation)).toHaveLength(0);
+        expect(yield* snapshotState(sql)).toBe('ready');
+        expect(yield* sql`SELECT token FROM snapshot_leases`).toEqual([]);
+      }),
+    ),
+  );
+
+  effectIt.effect('checks full authority only when the final retirement baton has no successor', () =>
+    withFixture(sql =>
+      Effect.gen(function* () {
+        yield* seedLease(sql, 'first', SNAPSHOT, true);
+        yield* seedLease(sql, 'last', SNAPSHOT, false, 120_000);
+        const queries = yield* observeQueries();
+        expect(yield* releaseSnapshotLease('first')).toBe(false);
+        expect(queries.filter(cleanupObservation)).toHaveLength(0);
+        expect(yield* sql`SELECT token, retire_when_inactive FROM snapshot_leases`).toEqual([
+          {retire_when_inactive: 1, token: 'last'},
+        ]);
+        queries.length = 0;
+        expect(yield* releaseSnapshotLease('last')).toBe(true);
+        expect(queries.some(cleanupObservation)).toBe(true);
+        expect(yield* snapshotState(sql)).toBe('retired');
+      }),
+    ),
+  );
+
+  for (const mutation of [
+    'ALTER TABLE removed_view_cleanup ADD COLUMN unexpected TEXT',
+    'DROP INDEX snapshots_base_state_id',
+  ]) {
+    effectIt.effect(`does not retire without current full authority: ${mutation}`, () =>
+      withFixture(sql =>
+        Effect.gen(function* () {
+          yield* seedLease(sql, 'last', SNAPSHOT, true);
+          yield* sql.unsafe(mutation);
+          const queries = yield* observeQueries();
+          expect(yield* releaseSnapshotLease('last')).toBe(false);
+          expect(queries.some(cleanupObservation)).toBe(true);
+          expect(yield* snapshotState(sql)).toBe('ready');
+          expect(yield* sql`SELECT token FROM snapshot_leases`).toEqual([]);
+        }),
+      ),
+    );
+  }
+
+  effectIt.effect('keeps narrow authority and malformed lease failures non-mutating', () =>
+    withFixture(sql =>
+      Effect.gen(function* () {
+        yield* seedLease(sql, 'clean', SNAPSHOT, false);
+        yield* sql`DROP INDEX snapshot_leases_expiry`;
+        expect(yield* Effect.flip(releaseSnapshotLease('clean'))).toMatchObject({
+          _tag: 'CodeGraphStoreError',
+          message: 'Code graph snapshot lease authority schema is invalid.',
+        });
+        expect(yield* sql`SELECT token FROM snapshot_leases`).toEqual([{token: 'clean'}]);
+        expect(yield* snapshotState(sql)).toBe('ready');
+        yield* sql`CREATE INDEX snapshot_leases_expiry ON snapshot_leases(expires_at)`;
+        yield* sql`UPDATE snapshot_leases SET expires_at = 'invalid' WHERE token = 'clean'`;
+        expect(yield* Effect.flip(releaseSnapshotLease('clean'))).toMatchObject({
+          _tag: 'CodeGraphStoreError',
+          message: 'Code graph snapshot lease manifest is invalid.',
+        });
+        expect(yield* sql`SELECT token, expires_at FROM snapshot_leases`).toEqual([
+          {expires_at: 'invalid', token: 'clean'},
+        ]);
+        expect(yield* snapshotState(sql)).toBe('ready');
+      }),
+    ),
+  );
+
+  effectIt.effect('retains independent expired-page retirement during an ordinary release', () =>
+    withFixture(sql =>
+      Effect.gen(function* () {
+        yield* seedSnapshot(sql, EXPIRED_SNAPSHOT);
+        yield* seedLease(sql, 'clean', SNAPSHOT, false);
+        yield* seedLease(sql, 'expired', EXPIRED_SNAPSHOT, true, 0);
+        const queries = yield* observeQueries();
+        expect(yield* releaseSnapshotLease('clean')).toBe(true);
+        expect(queries.some(cleanupObservation)).toBe(true);
+        expect(yield* snapshotState(sql)).toBe('ready');
+        expect(yield* snapshotState(sql, EXPIRED_SNAPSHOT)).toBe('retired');
+        expect(yield* sql`SELECT token FROM snapshot_leases`).toEqual([]);
+      }),
+    ),
+  );
+
+  effectIt.effect('omits unused SQL failures but preserves failures before required retirement', () =>
+    withFixture(sql =>
+      Effect.gen(function* () {
+        yield* seedLease(sql, 'clean', SNAPSHOT, false);
+        yield* seedLease(sql, 'last', SNAPSHOT, true);
+        yield* observeQueries(cleanupObservation);
+        expect(yield* releaseSnapshotLease('clean')).toBe(false);
+        expect(yield* Effect.flip(releaseSnapshotLease('last'))).toMatchObject({_tag: 'SqlError'});
+        expect(yield* sql`SELECT token FROM snapshot_leases`).toEqual([{token: 'last'}]);
+        expect(yield* snapshotState(sql)).toBe('ready');
+      }),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'preserves the baton across generated insertion and expiry order with sorted releases',
+    {
+      active: FC.boolean(),
+      flagged: FC.nat(5),
+      order: FC.uniqueArray(FC.integer({min: 0, max: 5}), {minLength: 1, maxLength: 6}),
+    },
+    ({active, flagged, order}) =>
+      withFixture(sql =>
+        Effect.gen(function* () {
+          const tokens = order.map(index => `reader-${index}`);
+          const carrier = tokens[flagged % tokens.length];
+          const remaining = new Set(tokens);
+          for (const [index, token] of tokens.entries()) {
+            yield* seedLease(sql, token, SNAPSHOT, token === carrier, 60_000 + index);
+          }
+          if (active) {
+            yield* sql`
+              INSERT INTO active_snapshots (worktree_id, snapshot_id, activated_at)
+              VALUES (${WORKTREE}, ${SNAPSHOT}, '1970-01-01T00:00:00.000Z')
+            `;
+          }
+          for (const token of [...tokens].sort()) {
+            remaining.delete(token);
+            expect(yield* releaseSnapshotLease(token)).toBe(!active && remaining.size === 0);
+            expect(yield* snapshotState(sql)).toBe(!active && remaining.size === 0 ? 'retired' : 'ready');
+            const leases = yield* sql<{readonly token: string; readonly retire_when_inactive: number}>`
+              SELECT token, retire_when_inactive FROM snapshot_leases ORDER BY token
+            `;
+            expect(leases.map(lease => lease.token)).toEqual([...remaining].sort());
+            expect(leases.filter(lease => lease.retire_when_inactive === 1)).toHaveLength(remaining.size > 0 ? 1 : 0);
+          }
+        }),
+      ),
+    {fastCheck: {numRuns: 24}},
+  );
+});
+
+function withFixture<A, E, R>(use: (sql: SqlClient.SqlClient) => Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* initializeSchema(sql);
+    yield* sql`
+      INSERT INTO repositories (id, display_name, object_format, created_at, last_used_at)
+      VALUES ('repository', 'fixture', 'sha1', '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z')
+    `;
+    yield* seedSnapshot(sql, SNAPSHOT);
+    return yield* use(sql);
+  }).pipe(provideTestLayer(SqliteClient.layer({filename: ':memory:', disableWAL: true})));
+}
+
+function seedSnapshot(sql: SqlClient.SqlClient, snapshotId: string) {
+  return Effect.gen(function* () {
+    yield* sql`
+      INSERT INTO snapshots (
+        id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id,
+        extractor_set, dirty, overlay_fingerprint, state, file_count, symbol_count,
+        edge_count, started_at, completed_at, failure_summary
+      ) VALUES (
+        ${snapshotId}, 'repository', ${WORKTREE}, ${'1'.repeat(40)}, ${`cgc_${snapshotId.slice(-40)}`}, NULL,
+        'fixture', 0, NULL, 'ready', 0, 0, 0, '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z', NULL
+      )
+    `;
+    yield* sql`
+      INSERT INTO snapshot_extractor_generations (snapshot_id, generation)
+      VALUES (${snapshotId}, ${CODE_GRAPH_EXTRACTOR_GENERATION})
+    `;
+  });
+}
+
+function seedLease(sql: SqlClient.SqlClient, token: string, snapshotId: string, flagged: boolean, duration = 60_000) {
+  return Effect.gen(function* () {
+    const now = yield* Clock.currentTimeMillis;
+    yield* sql`
+      INSERT INTO snapshot_leases (token, snapshot_id, expires_at, retire_when_inactive)
+      VALUES (${token}, ${snapshotId}, ${now + duration}, ${flagged ? 1 : 0})
+    `;
+  });
+}
+
+function snapshotState(sql: SqlClient.SqlClient, snapshotId = SNAPSHOT) {
+  return sql<{readonly state: string}>`SELECT state FROM snapshots WHERE id = ${snapshotId}`.pipe(
+    Effect.map(rows => rows[0]?.state),
+  );
+}
+
+const observeQueries = Effect.fn('test.observeLeaseQueries')(function* (fail?: (query: string) => boolean) {
+  const queries: string[] = [];
+  yield* Effect.acquireRelease(
+    Effect.sync(() => {
+      const original = Database.prototype.query;
+      return vi.spyOn(Database.prototype, 'query').mockImplementation(function (
+        this: Database,
+        ...args: Parameters<Database['query']>
+      ) {
+        queries.push(args[0]);
+        if (fail?.(args[0])) throw new Error('Required retirement observation fixture failure');
+        return Reflect.apply(original, this, args);
+      });
+    }),
+    spy => Effect.sync(() => spy.mockRestore()),
+  );
+  return queries;
+});

--- a/test/unit/code-graph.query-refresh-runtime.test.ts
+++ b/test/unit/code-graph.query-refresh-runtime.test.ts
@@ -1,0 +1,364 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Context, Effect, FileSystem, Layer, Path, Ref} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import {describe, expect} from 'vitest';
+import {
+  observeCodeGraphAdmissionEnvironment,
+  recordCodeGraphSnapshotAdmission,
+} from '../../src/code_graph/admission_freshness.js';
+import {CodeGraphEmbeddingIndex, type CodeGraphEmbeddingIndexShape} from '../../src/code_graph/embedding.js';
+import {
+  CodeGraphIndexer,
+  extractorSetIdentityFromPackProvenance,
+  type CodeGraphIndexerShape,
+} from '../../src/code_graph/indexer.js';
+import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
+import {CodeGraphQueryService, type CodeGraphInspectOptions} from '../../src/code_graph/query.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CodeGraphStore, type CodeGraphStoreShape} from '../../src/code_graph/store.js';
+import type {CodeGraphQueryNode, CodeGraphSnapshot} from '../../src/code_graph/types.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {TestError} from '../helpers/test-error.js';
+
+const platform = Layer.mergeAll(BunServices.layer, SystemInfo.layer, CodeGraphLanguagePackRegistry.layer);
+const dependencies = Layer.merge(platform, CommandExecutor.layer.pipe(Layer.provide(platform)));
+const node: CodeGraphQueryNode = {
+  contentHash: 'fixture',
+  exported: true,
+  id: `cgs_${'a'.repeat(32)}`,
+  kind: 'function',
+  language: 'typescript',
+  name: 'value',
+  path: 'source.ts',
+  qualifiedName: 'value',
+  score: 1,
+  span: {column: 1, endColumn: 2, endLine: 1, line: 1},
+};
+const operations = ['query', 'node', 'neighbors', 'explain', 'path', 'impact'] as const;
+
+// Real Git and admission receipts keep the currentness contract observable; only graph storage and indexing are modeled.
+const makeFixture = Effect.fn('test.makeQueryRuntimeFixture')(function* () {
+  const fixtureContext = yield* Effect.context<Layer.Success<typeof dependencies>>();
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const packs = yield* CodeGraphLanguagePackRegistry;
+  const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-query-runtime-'});
+  const repository = path.join(root, 'repository');
+  const home = path.join(root, 'home');
+  yield* fs.makeDirectory(repository);
+  const git = (args: readonly string[]) =>
+    runCommandEffect('git', ['-C', repository, ...args]).pipe(Effect.provide(fixtureContext));
+  yield* git(['init', '-q']);
+  yield* fs.writeFileString(path.join(repository, 'source.ts'), 'export const value = 1;\n');
+  yield* git(['add', 'source.ts']);
+  yield* git([
+    '-c',
+    'commit.gpgsign=false',
+    '-c',
+    'user.name=Threadnote Test',
+    '-c',
+    'user.email=test@threadnote.local',
+    'commit',
+    '-qm',
+    'fixture',
+  ]);
+  const identity = yield* resolveRepositoryIdentity(repository);
+  const layout = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId);
+  const snapshot: CodeGraphSnapshot = {
+    commit: identity.headCommit,
+    completedAt: '2026-08-08T00:00:00.000Z',
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: extractorSetIdentityFromPackProvenance([]),
+    fileCount: 1,
+    id: `cgsn_${'1'.repeat(40)}`,
+    repositoryId: identity.repositoryId,
+    state: 'ready',
+    symbolCount: 1,
+    worktreeId: identity.worktreeId,
+  };
+  const ready = yield* Ref.make<CodeGraphSnapshot | undefined>(snapshot);
+  const valid = yield* Ref.make(true);
+  const failProvenance = yield* Ref.make(false);
+  const failRead = yield* Ref.make(false);
+  const counters = yield* Ref.make({indexed: 0, provenance: 0, acquired: 0, released: 0, strict: 0});
+  const record = (field: 'indexed' | 'provenance' | 'acquired' | 'released' | 'strict') =>
+    Ref.update(counters, value => ({...value, [field]: value[field] + 1}));
+  const admission = (environment?: string) =>
+    Effect.gen(function* () {
+      yield* recordCodeGraphSnapshotAdmission(
+        layout,
+        snapshot,
+        environment ?? (yield* observeCodeGraphAdmissionEnvironment(identity)),
+        packs,
+        false,
+      );
+    }).pipe(Effect.provide(fixtureContext));
+  yield* admission();
+  const store = CodeGraphStore.of({
+    readySnapshot: () => Ref.get(ready),
+    readySnapshotById: () => Ref.get(ready),
+    snapshotPackProvenance: () =>
+      Effect.gen(function* () {
+        yield* record('provenance');
+        if (yield* Ref.get(failProvenance)) return yield* TestError.make({message: 'provenance read failed'});
+        return (yield* Ref.get(valid)) ? [] : undefined;
+      }),
+    acquireSnapshotLease: () => record('acquired').pipe(Effect.as('lease')),
+    releaseSnapshotLease: () => record('released'),
+    symbolsByIds: (_database: string, _snapshot: string, ids: readonly string[]) =>
+      Effect.gen(function* () {
+        if (yield* Ref.get(failRead)) return yield* TestError.make({message: 'graph read failed'});
+        return ids.includes(node.id) ? [node] : [];
+      }),
+    searchSymbolsMany: () => Effect.succeed([[node]]),
+    searchSymbolsByPaths: () => Effect.succeed([[node]]),
+    edgesForNodes: () => Effect.succeed([]),
+    withSession: (_database: string, use: Effect.Effect<unknown, unknown, unknown>) => use,
+  } as unknown as CodeGraphStoreShape);
+  const indexer = CodeGraphIndexer.of({
+    index: () =>
+      Effect.gen(function* () {
+        yield* record('indexed');
+        yield* Ref.set(ready, snapshot);
+        yield* Ref.set(valid, true);
+        yield* Ref.set(failProvenance, false);
+        yield* admission();
+      }),
+    ensureCommit: () => Effect.die(TestError.make({message: 'unexpected historical build'})),
+  } as unknown as CodeGraphIndexerShape);
+  const services = Layer.mergeAll(
+    dependencies,
+    Layer.succeed(CodeGraphStore, store),
+    Layer.succeed(CodeGraphIndexer, indexer),
+    Layer.succeed(
+      CodeGraphMaintenanceCoordinator,
+      CodeGraphMaintenanceCoordinator.of({
+        request: () => Effect.die(TestError.make({message: 'unexpected maintenance'})),
+      } as unknown as Context.Service.Shape<typeof CodeGraphMaintenanceCoordinator>),
+    ),
+    Layer.succeed(
+      CodeGraphEmbeddingIndex,
+      CodeGraphEmbeddingIndex.of({
+        search: () => Effect.succeed(new Map()),
+      } as unknown as CodeGraphEmbeddingIndexShape),
+    ),
+  );
+  const context = yield* Layer.build(CodeGraphQueryService.layer.pipe(Layer.provide(services)));
+  const query = Context.get(context, CodeGraphQueryService);
+  const inspect = (options: Partial<CodeGraphInspectOptions> = {}) =>
+    query.inspect({
+      cwd: repository,
+      threadnoteHome: home,
+      operation: 'node',
+      nodeId: node.id,
+      query: 'value',
+      from: node.id,
+      to: node.id,
+      requestMaintenance: false,
+      statusObservation: {identity},
+      telemetry: {
+        skip: () => Effect.void,
+        stage: (_phase, stage, effect) =>
+          stage === 'query-strict-reobservation' ? record('strict').pipe(Effect.andThen(effect)) : effect,
+      },
+      ...options,
+    });
+  return {admission, counters, failProvenance, failRead, fs, git, inspect, path, ready, repository, snapshot, valid};
+});
+
+describe('query runtime probe policy', () => {
+  for (const operation of operations) {
+    effectIt.effect(`preserves selected-snapshot and explicit refresh/strict checks for ${operation}`, () =>
+      Effect.gen(function* () {
+        const fixture = yield* makeFixture();
+        for (const refresh of [undefined, false, true] as const) {
+          for (const strictFreshness of [false, true]) {
+            yield* Ref.set(fixture.counters, {indexed: 0, provenance: 0, acquired: 0, released: 0, strict: 0});
+            const result = yield* fixture.inspect({operation, refresh, strictFreshness});
+            expect(result.freshness).toBe(refresh === false && !strictFreshness ? 'deferred' : 'current');
+            expect(result.nodes.map(value => value.id)).toContain(node.id);
+            const rebuildMode = refresh === true || operation === 'path' || operation === 'impact';
+            expect(yield* Ref.get(fixture.counters)).toEqual({
+              indexed: 0,
+              provenance: refresh !== false && rebuildMode ? 2 : 1,
+              acquired: 1,
+              released: 1,
+              strict: strictFreshness ? 1 : 0,
+            });
+          }
+        }
+      }).pipe(provideTestLayer(dependencies), TestClock.withLive),
+    );
+
+    effectIt.effect.prop(
+      `preserves cold-build, refresh, and stale-result policy for ${operation} across runtime validity`,
+      {
+        refresh: FC.constantFrom(undefined, false, true),
+        strictFreshness: FC.constantFrom(undefined, false, true),
+        available: FC.boolean(),
+        valid: FC.boolean(),
+      },
+      ({refresh, strictFreshness, available, valid}) =>
+        Effect.gen(function* () {
+          const fixture = yield* makeFixture();
+          yield* Ref.set(fixture.ready, available ? fixture.snapshot : undefined);
+          yield* Ref.set(fixture.valid, valid);
+          const run = fixture.inspect({operation, refresh, strictFreshness});
+          if (!available && refresh === false) {
+            expect(yield* run.pipe(Effect.flip)).toMatchObject({_tag: 'CodeGraphSnapshotUnavailable'});
+            expect(yield* Ref.get(fixture.counters)).toEqual({
+              indexed: 0,
+              provenance: 0,
+              acquired: 0,
+              released: 0,
+              strict: 0,
+            });
+            return;
+          }
+          const result = yield* run;
+          const refreshesStale =
+            refresh !== false && (refresh === true || operation === 'path' || operation === 'impact');
+          const builds = !available || (!valid && refreshesStale);
+          const observed = refresh !== false || (strictFreshness ?? (operation === 'path' || operation === 'impact'));
+          expect(result.freshness).toBe(!valid && !builds ? 'stale' : observed ? 'current' : 'deferred');
+          expect(result.nodes.map(value => value.id)).toContain(node.id);
+          expect(yield* Ref.get(fixture.counters)).toMatchObject({indexed: builds ? 1 : 0, acquired: 1, released: 1});
+        }).pipe(provideTestLayer(dependencies), TestClock.withLive),
+      // Four generated fixtures per operation: 24 total, separately bounded by the ordinary test timeout.
+      {fastCheck: {numRuns: 4}},
+    );
+  }
+
+  effectIt.effect('keeps cold auto-indexing and refresh decisions even when strict reobservation is disabled', () =>
+    Effect.gen(function* () {
+      const fixture = yield* makeFixture();
+      for (const refresh of [undefined, true, false] as const) {
+        yield* Ref.set(fixture.ready, undefined);
+        yield* Ref.set(fixture.counters, {indexed: 0, provenance: 0, acquired: 0, released: 0, strict: 0});
+        const run = fixture.inspect({refresh, strictFreshness: false});
+        if (refresh === false) {
+          expect(yield* run.pipe(Effect.flip)).toMatchObject({_tag: 'CodeGraphSnapshotUnavailable'});
+          expect(yield* Ref.get(fixture.counters)).toMatchObject({indexed: 0, acquired: 0, released: 0});
+        } else {
+          expect((yield* run).freshness).toBe('current');
+          expect(yield* Ref.get(fixture.counters)).toEqual({
+            indexed: 1,
+            provenance: 1,
+            acquired: 1,
+            released: 1,
+            strict: 0,
+          });
+        }
+      }
+      yield* Ref.set(fixture.ready, fixture.snapshot);
+      for (const operation of ['node', 'path', 'impact'] as const) {
+        yield* Ref.set(fixture.valid, false);
+        yield* Ref.set(fixture.counters, {indexed: 0, provenance: 0, acquired: 0, released: 0, strict: 0});
+        const result = yield* fixture.inspect({
+          operation,
+          refresh: operation === 'node' ? true : undefined,
+          strictFreshness: false,
+        });
+        expect(result.freshness).toBe('current');
+        expect(yield* Ref.get(fixture.counters)).toEqual({
+          indexed: 1,
+          provenance: 2,
+          acquired: 1,
+          released: 1,
+          strict: 0,
+        });
+      }
+    }).pipe(provideTestLayer(dependencies), TestClock.withLive),
+  );
+
+  effectIt.effect('observes invalid provenance after the worktree observation and retains balanced read leases', () =>
+    Effect.gen(function* () {
+      const fixture = yield* makeFixture();
+      const result = yield* fixture.inspect({interlock: {afterObservation: () => Ref.set(fixture.valid, false)}});
+      expect(result.freshness).toBe('stale');
+      expect(yield* Ref.get(fixture.counters)).toEqual({
+        indexed: 0,
+        provenance: 1,
+        acquired: 1,
+        released: 1,
+        strict: 0,
+      });
+      yield* Ref.set(fixture.failProvenance, true);
+      expect((yield* fixture.inspect()).freshness).toBe('stale');
+      yield* Ref.set(fixture.failRead, true);
+      expect(yield* fixture.inspect().pipe(Effect.flip)).toMatchObject({message: 'graph read failed'});
+      expect(yield* Ref.get(fixture.counters)).toMatchObject({indexed: 0, acquired: 3, released: 3});
+    }).pipe(provideTestLayer(dependencies), TestClock.withLive),
+  );
+
+  effectIt.effect(
+    'keeps selected admission and strict closing admission checks without the ordinary preflight probe',
+    () =>
+      Effect.gen(function* () {
+        const fixture = yield* makeFixture();
+        yield* fixture.admission('0'.repeat(64));
+        expect((yield* fixture.inspect()).freshness).toBe('stale');
+        yield* fixture.admission();
+        const strict = yield* fixture.inspect({
+          strictFreshness: true,
+          interlock: {
+            afterSnapshotSelected: () => fixture.admission('0'.repeat(64)).pipe(Effect.orDie),
+          },
+        });
+        expect(strict.freshness).toBe('stale');
+        expect(yield* Ref.get(fixture.counters)).toEqual({
+          indexed: 0,
+          provenance: 2,
+          acquired: 2,
+          released: 2,
+          strict: 1,
+        });
+      }).pipe(provideTestLayer(dependencies), TestClock.withLive),
+  );
+
+  effectIt.effect('retains strict closing worktree and repository identity reobservation', () =>
+    Effect.gen(function* () {
+      const fixture = yield* makeFixture();
+      const dirty = yield* fixture.inspect({
+        strictFreshness: true,
+        interlock: {
+          afterSnapshotSelected: () =>
+            fixture.fs
+              .writeFileString(fixture.path.join(fixture.repository, 'source.ts'), 'export const value = 2;\n')
+              .pipe(Effect.orDie),
+        },
+      });
+      expect(dirty.freshness).toBe('stale');
+      yield* fixture.git(['checkout', '--', 'source.ts']);
+      const changedIdentity = yield* fixture
+        .inspect({
+          strictFreshness: true,
+          interlock: {
+            afterSnapshotSelected: () =>
+              fixture
+                .git(['remote', 'add', 'origin', 'https://github.com/example/replaced.git'])
+                .pipe(Effect.asVoid, Effect.orDie),
+          },
+        })
+        .pipe(Effect.flip);
+      expect(changedIdentity).toMatchObject({
+        _tag: 'CodeGraphRepositoryError',
+        message: 'Repository identity changed during the graph read.',
+      });
+      expect(yield* Ref.get(fixture.counters)).toEqual({
+        indexed: 0,
+        provenance: 2,
+        acquired: 2,
+        released: 2,
+        strict: 2,
+      });
+    }).pipe(provideTestLayer(dependencies), TestClock.withLive),
+  );
+});

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -432,7 +432,7 @@ describe('code graph query budgets', () => {
             expect(yield* Ref.get(storeReads)).toEqual({
               leasesAcquired: 1,
               leasesReleased: 1,
-              provenance: 2,
+              provenance: refresh === true ? 2 : 1,
               readyById: 0,
               readyByWorktree: 2,
             });


### PR DESCRIPTION
Ordinary graph reads perform validation that their execution path cannot use: default queries repeat an early runtime/admission probe, and ordinary lease releases inspect the full retirement schema even when the released lease does not request retirement.

Skip the query preflight probe unless it can decide whether to refresh. Validate retirement authority when a flagged lease has no live successor and may actually retire its snapshot. Selected-snapshot validation, strict closing observations, lease authority, successor transfer, transactions, and expired-lease reaping retain their existing checks.

Validation: 41 focused tests passed on the combined commit, including real admission integration, the query-mode matrix, and 24 generated cases each for query freshness and lease transfer. The broader lease/cleanup/maintenance checks and both commits' normal precommit checks passed. Independent reviews verified both changes. The exact combined commit was globally installed and passed five isolated CLI checks for cold reads, ready reads, changed admission policy, stale labeling, and refresh recovery.

Performance budgets and benchmark inputs are unchanged. These checks establish correctness and removal of unused work; fresh hosted qualification is still required before releasing 4.6.8.
