### PR TITLE
Keep auto-update repair running when post-update fails

### DIFF
--- a/src/effect/cli_output.ts
+++ b/src/effect/cli_output.ts
@@ -1,4 +1,5 @@
 import {Console, Context, Effect, Layer, Logger, Schema} from 'effect';
+import {SystemInfo} from './system.js';
 
 class CliOutputError extends Schema.TaggedError<CliOutputError>()('CliOutputError', {
   cause: Schema.optionalKey(Schema.Defect()),
@@ -100,28 +101,32 @@ const formatConsoleArguments = (arguments_: readonly unknown[]): string =>
   arguments_.map(value => (typeof value === 'string' ? value : String(value))).join(' ');
 
 export class CliOutput extends Context.Service<CliOutput, CliOutputShape>()('threadnote/effect/cli_output/CliOutput') {
-  static readonly layer = Layer.sync(CliOutput, () => {
-    const stdout = makeQueuedCliWriter(() => Bun.stdout.writer({highWaterMark: 64 * 1024}), {
-      isTty: process.stdout.isTTY === true,
-    });
-    const stderr = makeQueuedCliWriter(() => Bun.stderr.writer({highWaterMark: 64 * 1024}), {
-      isTty: process.stderr.isTTY === true,
-    });
-    return CliOutput.of({
-      drain: Effect.tryPromise({
-        try: () => Promise.all([stdout.drain(), stderr.drain()]).then(() => undefined),
-        catch: cause => CliOutputError.make({cause, message: 'Failed to drain Threadnote CLI output.'}),
-      }),
-      enqueueError: stderr.enqueue,
-      enqueueOutput: stdout.enqueue,
-      flush: Effect.tryPromise({
-        try: () => Promise.all([stdout.flush(), stderr.flush()]).then(() => undefined),
-        catch: cause => CliOutputError.make({cause, message: 'Failed to flush Threadnote CLI output.'}),
-      }),
-      writeError: makeFinalCliOutput(stderr.write),
-      writeFinal: makeFinalCliOutput(stdout.write),
-    });
-  });
+  static readonly layer = Layer.effect(
+    CliOutput,
+    Effect.gen(function* () {
+      const system = yield* SystemInfo;
+      const stdout = makeQueuedCliWriter(() => Bun.stdout.writer({highWaterMark: 64 * 1024}), {
+        isTty: system.stdoutIsTTY,
+      });
+      const stderr = makeQueuedCliWriter(() => Bun.stderr.writer({highWaterMark: 64 * 1024}), {
+        isTty: system.stderrIsTTY === true,
+      });
+      return CliOutput.of({
+        drain: Effect.tryPromise({
+          try: () => Promise.all([stdout.drain(), stderr.drain()]).then(() => undefined),
+          catch: cause => CliOutputError.make({cause, message: 'Failed to drain Threadnote CLI output.'}),
+        }),
+        enqueueError: stderr.enqueue,
+        enqueueOutput: stdout.enqueue,
+        flush: Effect.tryPromise({
+          try: () => Promise.all([stdout.flush(), stderr.flush()]).then(() => undefined),
+          catch: cause => CliOutputError.make({cause, message: 'Failed to flush Threadnote CLI output.'}),
+        }),
+        writeError: makeFinalCliOutput(stderr.write),
+        writeFinal: makeFinalCliOutput(stdout.write),
+      });
+    }),
+  );
 }
 
 /** Routes Effect Console output through the same awaited, backpressured sinks as final payloads. */

--- a/src/effect/cli_output.ts
+++ b/src/effect/cli_output.ts
@@ -29,11 +29,17 @@ interface CliOutputSink {
   readonly write: (chunk: string) => number | Promise<number>;
 }
 
-const isBrokenPipeError = (cause: unknown): boolean =>
-  typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'EPIPE';
+const CONSUMER_GONE_ON_PIPE_CODES = new Set(['EBADF', 'ENOTTY']);
+
+const isConsumerGoneError = (cause: unknown, isTty: boolean): boolean => {
+  if (typeof cause !== 'object' || cause === null || !('code' in cause)) return false;
+  const code = String(cause.code);
+  return code === 'EPIPE' || (!isTty && CONSUMER_GONE_ON_PIPE_CODES.has(code));
+};
 
 /** @internal Exported so pipe-backpressure ordering can be regression-tested without a real subprocess. */
-export function makeQueuedCliWriter(open: () => CliOutputSink) {
+export function makeQueuedCliWriter(open: () => CliOutputSink, options: {readonly isTty?: boolean} = {}) {
+  const isTty = options.isTty === true;
   let sink: CliOutputSink | undefined;
   let tail = Promise.resolve();
   let failure: unknown;
@@ -50,9 +56,11 @@ export function makeQueuedCliWriter(open: () => CliOutputSink) {
         await sink.write(`${output}\n`);
         await sink.flush();
       } catch (cause) {
-        // A downstream Unix consumer such as `head` closing after its requested
-        // prefix is normal pipeline control flow, not a failed CLI operation.
-        if (!isBrokenPipeError(cause)) throw cause;
+        // `head` closing after its requested prefix is EPIPE. Detached
+        // auto-update children writing to ignored/invalid non-TTY stdio can
+        // also surface EBADF/ENOTTY. Interactive TTYs stay fail-closed for
+        // those codes so machine-readable writeFinal cannot silently drop.
+        if (!isConsumerGoneError(cause, isTty)) throw cause;
         consumerClosed = true;
       }
     });
@@ -75,7 +83,7 @@ export function makeQueuedCliWriter(open: () => CliOutputSink) {
         try {
           await sink.end();
         } catch (cause) {
-          if (!isBrokenPipeError(cause)) throw cause;
+          if (!isConsumerGoneError(cause, isTty)) throw cause;
           consumerClosed = true;
         }
       }
@@ -93,8 +101,12 @@ const formatConsoleArguments = (arguments_: readonly unknown[]): string =>
 
 export class CliOutput extends Context.Service<CliOutput, CliOutputShape>()('threadnote/effect/cli_output/CliOutput') {
   static readonly layer = Layer.sync(CliOutput, () => {
-    const stdout = makeQueuedCliWriter(() => Bun.stdout.writer({highWaterMark: 64 * 1024}));
-    const stderr = makeQueuedCliWriter(() => Bun.stderr.writer({highWaterMark: 64 * 1024}));
+    const stdout = makeQueuedCliWriter(() => Bun.stdout.writer({highWaterMark: 64 * 1024}), {
+      isTty: process.stdout.isTTY === true,
+    });
+    const stderr = makeQueuedCliWriter(() => Bun.stderr.writer({highWaterMark: 64 * 1024}), {
+      isTty: process.stderr.isTTY === true,
+    });
     return CliOutput.of({
       drain: Effect.tryPromise({
         try: () => Promise.all([stdout.drain(), stderr.drain()]).then(() => undefined),

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -44,7 +44,18 @@ export interface DetachedCommandOptions {
 
 export interface StreamingCommandOptions {
   readonly env?: NodeJS.ProcessEnv;
+  /**
+   * Inherit child stdout/stderr from this process. Only safe on a live TTY;
+   * detached auto-update workers inherit ignored stdio and must pipe so
+   * failures can be captured.
+   */
   readonly inheritOutput?: boolean;
+  /**
+   * Inherit child stdin. Independent of `inheritOutput` so `threadnote update | tee`
+   * can still answer prompts while piping logs. Detached workers leave this
+   * unset so stdin is ignored.
+   */
+  readonly inheritStdin?: boolean;
   readonly maxOutputChars?: number;
 }
 
@@ -390,33 +401,45 @@ const executeStreamingCommand = Effect.fn('CommandExecutor.executeStreaming')(fu
           ),
         catch: spawnFailed,
       });
+      const inheritOutput = options.inheritOutput === true;
+      const inheritStdin = options.inheritStdin === true || inheritOutput;
       const handle = yield* ChildProcess.make(invocation.executable, [...invocation.args], {
         env: commandEnvironment(executable, options.env, environment),
         forceKillAfter: 1000,
         shell: invocation.shell,
-        stdin: 'inherit',
-        stderr: options.inheritOutput === true ? 'inherit' : 'pipe',
-        stdout: options.inheritOutput === true ? 'inherit' : 'pipe',
+        stdin: inheritStdin ? 'inherit' : 'ignore',
+        stderr: inheritOutput ? 'inherit' : 'pipe',
+        stdout: inheritOutput ? 'inherit' : 'pipe',
       }).pipe(Effect.mapError(spawnFailed));
-      if (options.inheritOutput === true) {
-        return {exitCode: Number(yield* handle.exitCode), stderr: '', stdout: ''};
+      if (inheritOutput) {
+        return {
+          exitCode: Number(yield* handle.exitCode.pipe(Effect.mapError(spawnFailed))),
+          stderr: '',
+          stdout: '',
+        };
       }
       const stdio = yield* Stdio.Stdio;
       const [stdout, stderr, exitCode] = yield* Effect.all(
         [
-          collectStreamingOutput(handle.stdout, stdio.stdout({endOnDone: false}), maxOutputChars),
-          collectStreamingOutput(handle.stderr, stdio.stderr({endOnDone: false}), maxOutputChars),
-          handle.exitCode.pipe(Effect.map(Number)),
+          collectStreamingOutput(handle.stdout, stdio.stdout({endOnDone: false}), maxOutputChars).pipe(
+            Effect.orElseSucceed(() => ''),
+          ),
+          collectStreamingOutput(handle.stderr, stdio.stderr({endOnDone: false}), maxOutputChars).pipe(
+            Effect.orElseSucceed(() => ''),
+          ),
+          handle.exitCode.pipe(
+            Effect.map(Number),
+            Effect.orElseSucceed(() => 1),
+          ),
         ],
         {concurrency: 'unbounded'},
       );
       return {exitCode, stderr, stdout};
     }),
   ).pipe(
-    Effect.catch(cause => {
-      const message = causeMessage(cause);
-      return Effect.succeed({exitCode: 1, stderr: `${message}\n`, stdout: ''});
-    }),
+    Effect.catchIf(Schema.is(CommandSpawnFailed), cause =>
+      Effect.succeed({exitCode: 1, stderr: `${cause.message}\n`, stdout: ''}),
+    ),
   );
 });
 
@@ -502,7 +525,13 @@ function collectStreamingOutput(
     Stream.runFoldEffect(
       () => '',
       (current, chunk) =>
-        Stream.run(Stream.make(chunk), sink).pipe(Effect.as(appendOutputTail(current, chunk, maxOutputChars))),
+        // Parent stdout/stderr may be ignored (detached auto-update). Keep
+        // draining the child so a full pipe cannot deadlock, and keep the
+        // capture even when the parent tee write fails.
+        Stream.run(Stream.make(chunk), sink).pipe(
+          Effect.ignore,
+          Effect.as(appendOutputTail(current, chunk, maxOutputChars)),
+        ),
     ),
   );
 }

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -32,6 +32,7 @@ import {anonymousTelemetryLayer} from './telemetry.js';
 
 const systemLayer = SystemInfo.layer;
 const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
+const cliOutputLayer = CliOutput.layer.pipe(Layer.provide(systemLayer));
 export const StandaloneBrokerLayer = Layer.mergeAll(
   systemLayer,
   BunServices.layer,
@@ -80,7 +81,7 @@ const codeGraphQueryLayer = CodeGraphQueryService.layer.pipe(Layer.provideMerge(
 const codeGraphWatcherLayer = CodeGraphWatcher.layer.pipe(Layer.provideMerge(codeGraphIndexerLayer));
 
 const ApplicationServicesLayer = Layer.mergeAll(
-  CliOutput.layer,
+  cliOutputLayer,
   codeGraphQueryLayer,
   codeGraphAnalysisLayer,
   codeGraphWatcherLayer,

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -323,6 +323,7 @@ export interface SystemInfoShape {
   readonly setEnvironmentVariable: (name: string, value: string) => void;
   readonly stdinIsTTY: boolean;
   readonly stdoutIsTTY: boolean;
+  readonly stderrIsTTY?: boolean;
   readonly tempDirectory: string;
   readonly userId?: number;
   readonly userName: string;
@@ -509,6 +510,7 @@ export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('
         },
         stdinIsTTY: process.stdin.isTTY === true,
         stdoutIsTTY: process.stdout.isTTY === true,
+        stderrIsTTY: process.stderr.isTTY === true,
         tempDirectory:
           Option.getOrUndefined(tmpdir) ??
           Option.getOrUndefined(temp) ??

--- a/src/release/update.ts
+++ b/src/release/update.ts
@@ -31,6 +31,7 @@ import {
 import {hasLegacyLifecycleHandoffCandidates, hasProjectNameMigrationCandidates} from '../memory/index.js';
 import {isLegacyHomeMigrationPending, isThreadnoteHomeMigrationPending} from '../migration/home.js';
 import {whatsNewLinesForVersionRange} from './notes.js';
+import {redactSensitiveText} from '../share/scrubber.js';
 import {sendSystemNotification} from '../system_notification.js';
 import {readTelemetryConsentRenewal} from '../telemetry/config.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions} from '../types.js';
@@ -66,6 +67,7 @@ const POST_UPDATE_LOCK_OPTIONS = {
   staleAfterMilliseconds: 60_000,
   waitTimeoutMilliseconds: 10 * 60_000,
 } as const;
+export const STREAMING_SUBCOMMAND_FAILURE_DETAIL_LIMIT = 2_000;
 
 interface UpdateInfo {
   readonly channel: UpdateChannel;
@@ -305,13 +307,23 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     latestVersion,
     ...(options.yes === true ? ['--yes'] : []),
   ];
-  if (options.postUpdate !== false) {
-    // The child announces only when it finds evidence-backed work. Keeping the
-    // wrapper quiet prevents fresh installs from looking as if a migration was
-    // offered when the post-update command intentionally produced no output.
-    yield* runStreamingSubcommand(dryRun, threadnoteCommand, postUpdateArgs, false);
-  } else {
+  // The child announces only when it finds evidence-backed work. Keeping the
+  // wrapper quiet prevents fresh installs from looking as if a migration was
+  // offered when the post-update command intentionally produced no output.
+  const postUpdateResult =
+    options.postUpdate === false
+      ? undefined
+      : yield* Effect.result(runStreamingSubcommand(dryRun, threadnoteCommand, postUpdateArgs, false));
+  if (options.postUpdate === false) {
     yield* Console.log('Skipping post-update migration prompts because --no-post-update was provided.');
+  } else if (postUpdateResult !== undefined && Result.isFailure(postUpdateResult) && shouldRepair) {
+    // Promotion already succeeded. Keep going so MCP/hooks still get repaired
+    // even when the new binary's post-update child exits non-zero.
+    yield* Console.error(
+      warning(
+        `Post-update did not finish. Continuing with local setup repair. ${errorMessage(postUpdateResult.failure)}`,
+      ),
+    );
   }
   if (shouldRepair) {
     yield* Console.log('');
@@ -322,12 +334,15 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
       'Skipping local integration repair because --no-repair was provided. MCP host configurations were not refreshed.',
     );
   }
+  yield* withStandaloneInstallationLock(pruneStandaloneReleases(releaseRoot, dryRun), dryRun);
+  if (postUpdateResult !== undefined && Result.isFailure(postUpdateResult)) {
+    return yield* postUpdateResult.failure;
+  }
   yield* Console.log(
     shouldRepair
       ? 'Update complete. Brokered MCP sessions will use the new version on their next request. Legacy direct-server sessions migrated by repair require one host restart.'
       : 'Update complete. Brokered MCP sessions will use the new version on their next request. Hosts still using the legacy direct server command must run `threadnote repair` and restart once.',
   );
-  yield* withStandaloneInstallationLock(pruneStandaloneReleases(releaseRoot, dryRun), dryRun);
   yield* printWhatsNewIfAvailable(info);
 });
 
@@ -682,9 +697,10 @@ export function maybeRunPostUpdateAfterRepair(config: RuntimeConfig, options: {r
 }
 
 /**
- * Run a subprocess with its stdout/stderr inherited so the user sees output
- * live, instead of buffering through the regular command runner. Dry-run
- * defers to `maybeRun` so it only prints the command it would run.
+ * Run a subprocess with live stdout/stderr. Interactive TTYs inherit stdio;
+ * non-TTY callers (including the detached auto-update worker) pipe and capture
+ * output so a non-zero exit still has a diagnosable message. Dry-run defers to
+ * `maybeRun` so it only prints the command it would run.
  */
 function runStreamingSubcommand(
   dryRun: boolean,
@@ -693,20 +709,43 @@ function runStreamingSubcommand(
   announce: boolean = true,
 ) {
   if (dryRun) {
-    return maybeRunEffect(true, executable, args).pipe(Effect.asVoid);
+    return maybeRunEffect(true, executable, args).pipe(
+      Effect.asVoid,
+      Effect.mapError(cause => applicationError('run interactive subcommand', cause)),
+    );
   }
   return Effect.gen(function* () {
     if (announce) yield* Console.log(`Running: ${formatShellCommand(executable, args)}`);
+    const system = yield* SystemInfo;
     const result = yield* runStreamingCommandEffect(executable, args, {
-      inheritOutput: true,
+      inheritOutput: system.stdoutIsTTY,
+      inheritStdin: system.stdinIsTTY,
     });
     if (result.exitCode !== 0) {
       return yield* applicationError(
         'run interactive subcommand',
-        UpdateOperationError.make({message: `${formatShellCommand(executable, args)} exited with ${result.exitCode}.`}),
+        UpdateOperationError.make({message: streamingSubcommandFailureMessage(executable, args, result)}),
       );
     }
   });
+}
+
+/** @internal Exported so failure-text redaction and truncation can be property-tested. */
+export function streamingSubcommandFailureMessage(
+  executable: string,
+  args: readonly string[],
+  result: {readonly exitCode: number; readonly stderr: string; readonly stdout: string},
+): string {
+  const command = formatShellCommand(executable, args);
+  const preferred = redactSensitiveText(result.stderr.trim() || result.stdout.trim());
+  if (preferred.length === 0) {
+    return `${command} exited with ${result.exitCode}.`;
+  }
+  const truncated =
+    preferred.length > STREAMING_SUBCOMMAND_FAILURE_DETAIL_LIMIT
+      ? `…${preferred.slice(-STREAMING_SUBCOMMAND_FAILURE_DETAIL_LIMIT)}`
+      : preferred;
+  return `${command} exited with ${result.exitCode}. ${truncated}`;
 }
 
 function getUpdateInfo(

--- a/test/unit/cli-ui.progress.test.ts
+++ b/test/unit/cli-ui.progress.test.ts
@@ -101,24 +101,78 @@ describe('CLI progress indicator', () => {
     },
   );
 
-  it('preserves arbitrary non-EPIPE sink failures', async () => {
+  it.each(
+    (['EBADF', 'ENOTTY'] as const).flatMap(code =>
+      (['write', 'flush', 'end'] as const).map(failureStage => ({code, failureStage})),
+    ),
+  )('silently stops writing after $code on a non-TTY sink during $failureStage', async ({code, failureStage}) => {
+    const events: string[] = [];
+    const invalidFd = Object.assign(new Error('invalid fd'), {code});
+    const sinkOperation = (operation: 'end' | 'flush' | 'write') => {
+      events.push(operation);
+      if (failureStage === operation) throw invalidFd;
+      return 0;
+    };
+    const writer = makeQueuedCliWriter(
+      () => ({
+        end: () => sinkOperation('end'),
+        flush: () => sinkOperation('flush'),
+        write: () => sinkOperation('write'),
+      }),
+      {isTty: false},
+    );
+
+    await writer.write('requested-prefix');
+    await writer.drain();
+    await writer.write('unrequested-suffix');
+    await writer.drain();
+
+    expect(events).toEqual(
+      failureStage === 'write' ? ['write'] : failureStage === 'flush' ? ['write', 'flush'] : ['write', 'flush', 'end'],
+    );
+  });
+
+  it('keeps EBADF fail-closed on a TTY sink', async () => {
+    const failure = Object.assign(new Error('bad fd'), {code: 'EBADF'});
+    const writer = makeQueuedCliWriter(
+      () => ({
+        end: () => 0,
+        flush: () => 0,
+        write: () => {
+          throw failure;
+        },
+      }),
+      {isTty: true},
+    );
+
+    await expect(writer.write('complete-json')).rejects.toBe(failure);
+    await expect(writer.flush()).rejects.toBe(failure);
+  });
+
+  it('preserves non-consumer-gone sink failures for TTY and pipe writers', async () => {
     await fc.assert(
-      fc.asyncProperty(
-        fc.string().filter(code => code !== 'EPIPE'),
-        async code => {
-          const failure = Object.assign(new Error('sink failure'), {code});
-          const writer = makeQueuedCliWriter(() => ({
+      fc.asyncProperty(fc.boolean(), fc.string(), async (isTty, code) => {
+        const consumerGone = code === 'EPIPE' || (!isTty && (code === 'EBADF' || code === 'ENOTTY'));
+        const failure = Object.assign(new Error('sink failure'), {code});
+        const writer = makeQueuedCliWriter(
+          () => ({
             end: () => 0,
             flush: () => 0,
             write: () => {
               throw failure;
             },
-          }));
+          }),
+          {isTty},
+        );
 
+        if (consumerGone) {
+          await expect(writer.write('complete-json')).resolves.toBeUndefined();
+          await expect(writer.flush()).resolves.toBeUndefined();
+        } else {
           await expect(writer.write('complete-json')).rejects.toBe(failure);
           await expect(writer.flush()).rejects.toBe(failure);
-        },
-      ),
+        }
+      }),
       {numRuns: 64},
     );
   });

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -1,3 +1,4 @@
+import {it as effectIt} from '@effect/vitest';
 import {TestError} from '../helpers/test-error.js';
 import {mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
@@ -10,6 +11,7 @@ import {
   runDetachedCommandEffect,
   runStreamingCommandEffect,
 } from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {
   TELEMETRY_AGENT_SESSION_ENVIRONMENT_VARIABLE,
   TELEMETRY_CHILD_ENVIRONMENT_VARIABLE,
@@ -17,6 +19,7 @@ import {
   TELEMETRY_PROVIDER_ENVIRONMENT_VARIABLE,
   TELEMETRY_PROVIDER_SESSION_TOKEN_ENVIRONMENT_VARIABLE,
 } from '../../src/telemetry/session.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
 import {runEffect as run} from '../helpers/effect-runtime.js';
 
 describe('Effect CommandExecutor', () => {
@@ -137,6 +140,38 @@ describe('Effect CommandExecutor', () => {
 
     expect(result).toEqual({exitCode: 0, stderr: '', stdout: ''});
   });
+
+  effectIt.effect('captures stderr from non-inherited streaming failures', () =>
+    runStreamingCommandEffect(process.execPath, ['-e', 'process.stderr.write("post-update boom"); process.exit(1)'], {
+      inheritOutput: false,
+    }).pipe(
+      Effect.tap(result =>
+        Effect.sync(() => {
+          expect(result.exitCode).toBe(1);
+          expect(result.stderr).toContain('post-update boom');
+        }),
+      ),
+      provideTestLayer(ApplicationLayer),
+    ),
+  );
+
+  effectIt.effect('closes stdin for non-inherited streaming commands', () =>
+    runStreamingCommandEffect(
+      process.execPath,
+      [
+        '-e',
+        'process.stdin.resume(); process.stdin.on("data", () => process.exit(2)); process.stdin.on("end", () => process.exit(0)); setTimeout(() => process.exit(3), 2000)',
+      ],
+      {inheritOutput: false},
+    ).pipe(
+      Effect.tap(result =>
+        Effect.sync(() => {
+          expect(result.exitCode).toBe(0);
+        }),
+      ),
+      provideTestLayer(ApplicationLayer),
+    ),
+  );
 
   it('waits for a complete detached-child receipt instead of treating file creation as completion', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'threadnote-detached-receipt-'));

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -57,6 +57,8 @@ import {
   runPostUpdate,
   runUpdate,
   shouldPreferActiveInstalledVersion,
+  streamingSubcommandFailureMessage,
+  STREAMING_SUBCOMMAND_FAILURE_DETAIL_LIMIT,
   verifyOfficialPlatformSignature,
 } from '../../src/release/index.js';
 import * as utils from '../../src/utils.js';
@@ -1299,6 +1301,86 @@ describe('standalone updater', () => {
     }),
   );
 
+  effectIt.effect('repairs the promoted release even when post-update exits non-zero', () =>
+    Effect.gen(function* () {
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('4.0.0-beta.7'));
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-update-post-update-fail-'});
+          const installRoot = path.join(temporaryRoot, 'install');
+          const binRoot = path.join(temporaryRoot, 'bin');
+          const config = runtimeConfig(path.join(temporaryRoot, 'home'));
+          const artifactName = releaseArtifactName(baseSystem);
+          const archivePath = path.join(temporaryRoot, artifactName);
+          const executableName = baseSystem.platform === 'win32' ? 'threadnote.exe' : 'threadnote';
+          yield* writeReleaseArchive(archivePath, artifactName, executableName, RELEASE_VERSION);
+          const checksum = yield* sha256FileHex(archivePath);
+          const release = releaseResponse(RELEASE_VERSION, false, artifactName);
+          const http = updateHttpService(fs, archivePath, checksum, artifactName, [release]);
+          const streaming: Array<{
+            readonly args: readonly string[];
+            readonly inheritOutput: boolean | undefined;
+            readonly inheritStdin: boolean | undefined;
+          }> = [];
+          const commandExecutor = CommandExecutor.of({
+            execute: (executable, args) =>
+              Effect.sync(() => ({
+                exitCode: 0,
+                stderr: '',
+                stdout: executable === 'file' && args.at(-1)?.endsWith('.so') ? 'Mach-O 64-bit bundle\n' : '',
+              })),
+            executeStreaming: (_executable, args, options) =>
+              Effect.sync(() => {
+                streaming.push({
+                  args: [...args],
+                  inheritOutput: options?.inheritOutput,
+                  inheritStdin: options?.inheritStdin,
+                });
+                if (args[0] === 'post-update') {
+                  return {exitCode: 1, stderr: 'detached inherit failed\n', stdout: ''};
+                }
+                return {exitCode: 0, stderr: '', stdout: ''};
+              }),
+          });
+          const testSystem = SystemInfo.of({
+            ...baseSystem,
+            environment: () => ({
+              ...baseSystem.environment(),
+              LOCALAPPDATA: path.join(temporaryRoot, 'local-app-data'),
+              THREADNOTE_BIN_DIR: binRoot,
+              THREADNOTE_INSTALL_ROOT: installRoot,
+            }),
+            homeDirectory: path.join(temporaryRoot, 'user-home'),
+            stdinIsTTY: false,
+            stdoutIsTTY: false,
+          });
+
+          const captured = yield* captureConsole(
+            runUpdate(config, {stable: true, yes: true}).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(HttpService, http),
+              Effect.provideService(SystemInfo, testSystem),
+              Effect.flip,
+            ),
+          );
+          return {captured, streaming};
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(result.streaming.map(entry => entry.args[0])).toEqual(['post-update', 'repair']);
+      expect(result.streaming.every(entry => entry.inheritOutput === false)).toBe(true);
+      expect(result.streaming.every(entry => entry.inheritStdin === false)).toBe(true);
+      expect(result.captured.output).toContain('Post-update did not finish. Continuing with local setup repair.');
+      expect(result.captured.output).toContain('Repairing local Threadnote setup after standalone update.');
+      expect(result.captured.output).not.toContain('Update complete.');
+      expect(String(result.captured.value)).toContain('exited with 1');
+      expect(String(result.captured.value)).toContain('detached inherit failed');
+    }),
+  );
+
   effectIt.effect('refuses to execute an in-place Threadnote 3 to 4 transition', () =>
     Effect.gen(function* () {
       vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('3.0.5'));
@@ -2068,6 +2150,56 @@ describe('post-update validation', () => {
         state: '{"handledMigrationIds": [',
       });
     }),
+  );
+});
+
+describe('streaming subcommand failure messages', () => {
+  it('redacts secrets in captured child output', () => {
+    const message = streamingSubcommandFailureMessage('threadnote', ['post-update'], {
+      exitCode: 1,
+      stderr: 'Authorization: Bearer super-secret-token-value-abcdef',
+      stdout: '',
+    });
+    expect(message).toContain('exited with 1.');
+    expect(message).not.toContain('super-secret-token-value-abcdef');
+    expect(message).toContain('[REDACTED]');
+  });
+
+  effectIt.effect.prop(
+    'keeps the exit code and a tail of preferred child output',
+    {
+      extra: fc.integer({max: 400, min: 0}),
+      exitCode: fc.integer({max: 255, min: 1}),
+      stream: fc.constantFrom('stderr' as const, 'stdout' as const),
+    },
+    ({extra, exitCode, stream}) =>
+      Effect.sync(() => {
+        const overflow = extra > 0;
+        const body = overflow
+          ? `UNIQUEHEAD${'m'.repeat(STREAMING_SUBCOMMAND_FAILURE_DETAIL_LIMIT + extra)}UNIQUETAIL`
+          : 'ok-detail';
+        const stderr = stream === 'stderr' ? body : '';
+        const stdout = stream === 'stdout' ? body : 'ignored-stdout-noise';
+        const message = streamingSubcommandFailureMessage('/tmp/threadnote', ['post-update', '--yes'], {
+          exitCode,
+          stderr,
+          stdout,
+        });
+        expect(message).toContain(`exited with ${exitCode}.`);
+        const preferred = stderr.trim() || stdout.trim();
+        if (overflow) {
+          expect(message).toContain('…');
+          expect(message).toContain('UNIQUETAIL');
+          expect(message).not.toContain('UNIQUEHEAD');
+        } else {
+          expect(message).toContain(preferred);
+          expect(message).not.toContain('…');
+        }
+        if (stream === 'stderr') {
+          expect(message).not.toContain('ignored-stdout-noise');
+        }
+      }),
+    {fastCheck: {numRuns: 64}},
   );
 });
 


### PR DESCRIPTION
## Summary
- Detached auto-update workers inherit ignored stdio, so a successful promote could still fail in `post-update` with an opaque `exited with 1` and skip `repair --no-post-update`.
- Pipe and capture non-TTY streaming children, keep stdin independent of piped logs, and include a redacted tail of child output in the failure.
- After a successful promote, still run repair and prune even when post-update fails, then rethrow so `repairRequired` stays set.

## Test plan
- [x] Focused unit tests: `test/unit/update.test.ts`, `test/unit/effect-command.test.ts`, `test/unit/cli-ui.progress.test.ts`
- [x] Property: failure text keeps the exit code and a tail of preferred child output (stderr, else stdout), including overflow past 2k
- [ ] CI full suite
- [ ] After merge/install: `threadnote update --status` no longer hides the inner post-update cause; a background update still repairs local setup when post-update exits non-zero