### PR TITLE
Release Threadnote 4.6.9

### DIFF
--- a/.github/release-notes/v4.6.9.md
+++ b/.github/release-notes/v4.6.9.md
@@ -8,7 +8,7 @@ Failed graph-build cards in Manager expire after one hour instead of staying on 
 
 ### Compact graph CLI progress
 
-`threadnote graph index`, `threadnote graph repair`, `threadnote graph purge`, and `threadnote graph compact` rewrite one TTY status line with phase, counts, and an ETA when available instead of flooding the terminal. `--json` output is unchanged. `threadnote repair` prints the repair summary and then doctor after the spinner stops; doctor uses `Checking · …` for the native graph check.
+`threadnote graph index`, `threadnote graph repair`, `threadnote graph purge`, and `threadnote graph compact` rewrite one TTY status line with phase, counts, and an ETA when available instead of flooding the terminal. `--json` output is unchanged. Manager-captured graph actions still return only the final summary. `threadnote repair` prints the repair summary and then doctor after the spinner stops; doctor uses `Checking · …` for the native graph check.
 
 ### Manager graph maintenance
 

--- a/.github/release-notes/v4.6.9.md
+++ b/.github/release-notes/v4.6.9.md
@@ -1,0 +1,23 @@
+## What's new
+
+Threadnote 4.6.9 keeps graph CLI progress on one TTY status line, shows Manager maintenance ETA, expires failed graph-build cards after an hour, and honors checkout-local `.threadnoteignore.local`.
+
+### Failed graph-build cards
+
+Failed graph-build cards in Manager expire after one hour instead of staying on the dashboard indefinitely.
+
+### Compact graph CLI progress
+
+`threadnote graph index`, `threadnote graph repair`, `threadnote graph purge`, and `threadnote graph compact` rewrite one TTY status line with phase, counts, and an ETA when available instead of flooding the terminal. `--json` output is unchanged. `threadnote repair` prints the repair summary and then doctor after the spinner stops; doctor uses `Checking · …` for the native graph check.
+
+### Manager graph maintenance
+
+Manager shows graph maintenance phase progress and an ETA when completed/total is available, including home-wide purge.
+
+### Local ignore files
+
+`.threadnoteignore.local` is an uncommitted additive union with committed `.threadnoteignore`. A path ignored in either file is skipped, and a local `!` rule cannot un-ignore a committed exclude. Keep the local file uncommitted for machine-specific extra excludes. `threadnote graph inventory` reports both sources.
+
+### Residual graph cleanup
+
+Automatic residual maintenance uses larger cache cleanup pages and a longer tail window so leftover graph cache drains faster. Safety locks are unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+# Checkout-local extra graph excludes; keep uncommitted.
+.threadnoteignore.local
 node_modules/
 dist/
 site-dist/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,10 +152,10 @@ errors are reported as removal errors rather than being mislabeled as lock failu
 
 ## Seed is slow or skips files
 
-Threadnote applies `.threadnoteignore` while walking the filesystem, before entering ignored directories. The default
-rules exclude dependency and build caches such as `node_modules/` and `.nx/`. Broad patterns also skip every directory
-whose name starts with `.`, while an explicitly named manifest pattern such as `.github/**` or `.claude/**` still
-includes that directory.
+Threadnote applies the packaged `.threadnoteignore` while walking the filesystem, before entering ignored directories.
+The default rules exclude dependency and build caches such as `node_modules/` and `.nx/`. Broad patterns also skip every
+directory whose name starts with `.`, while an explicitly named manifest pattern such as `.github/**` or `.claude/**`
+still includes that directory.
 
 Each project is limited to 20,000 candidates, 250,000 visited non-ignored entries, and 4 MiB per file. Narrow the
 project's seed patterns or extend `.threadnoteignore` if a limit is reported. A failed project no longer prevents later
@@ -278,8 +278,11 @@ larger bounded sample. Human status and Manager continue to use the complete int
 
 `threadnote graph inventory` is a non-mutating, aggregate-only admission preview. It reports exact file and byte totals
 for eligible and skipped inputs, grouped by language, file role, language-pack classifier, and decision reason. The
-breakdown makes SVG, heavy/generated JSON, Git ignore, and `.threadnoteignore` decisions visible while separately
-showing admitted TypeScript, package manifests, Nx configuration, and TypeScript configuration. Add `--json` for the
+breakdown makes SVG, heavy/generated JSON, Git ignore, committed `.threadnoteignore`, and uncommitted
+`.threadnoteignore.local` decisions visible while separately
+showing admitted TypeScript, package manifests, Nx configuration, and TypeScript configuration. The two Threadnote ignore
+files use the same pattern syntax and are combined as a union, so a path ignored in either file is skipped. Keep
+`.threadnoteignore.local` uncommitted for machine-specific extra excludes in large monorepos. Add `--json` for the
 versioned path-free payload. Ordinary source blobs are not hydrated; Threadnote reads only the small resolution
 manifests needed to apply the same declared-source-root rules as indexing.
 
@@ -290,9 +293,8 @@ an exceeded scan/rewrite bound still triggers a correctness-preserving full mate
 projects, Threadnote performs one bounded candidate scan in the current file context so imports that become resolvable
 after a module is added are included in the incremental rewrite.
 
-Interactive indexing shows each Git read batch, then each extraction file and language with parse timing, followed by
-the persistence batches. Long pauses can therefore be attributed to input, parsing, or SQLite publication instead of
-appearing as an undifferentiated spinner. Generated roots such as `node_modules`, `dist`, `build`, `out`, hidden caches, and
+Interactive indexing rewrites one compact status line (TTY `\r`) with phase, counts, and an ETA when available. File
+paths and per-file parse/persist timings stay out of scrollback. Generated roots such as `node_modules`, `dist`, `build`, `out`, hidden caches, and
 `bazel-*` are pruned before reads. SVG and snapshot/golden/fixture or generated JSON/JSONC are excluded before blob
 reads and hashing. Generic JSON/JSONC at or above 256 KiB is also excluded, while recognized package, Nx, TypeScript,
 schema, and configuration inputs remain eligible below their separate 1 MiB safety cap.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/cli_ui.ts
+++ b/src/cli_ui.ts
@@ -205,6 +205,12 @@ const LINE_PROGRESS_INTERVAL_MILLISECONDS = 1_000;
 export const startProgress = Effect.fn('cliUi.startProgress')(function* (message: string) {
   const system = yield* SystemInfo;
   const environment = system.environment();
+  if (environment.THREADNOTE_NO_PROGRESS !== undefined) {
+    return {
+      stop: Effect.void,
+      update: (_nextMessage: string) => Effect.void,
+    };
+  }
   if (!system.stdoutIsTTY || environment.CI !== undefined || environment.THREADNOTE_NO_SPINNER !== undefined) {
     yield* Console.log(message);
     const state = yield* Ref.make<LineProgressState>({

--- a/src/cli_ui.ts
+++ b/src/cli_ui.ts
@@ -170,6 +170,30 @@ export interface ProgressIndicator {
   readonly stop: Effect.Effect<void>;
 }
 
+const INTERACTIVE_PROGRESS_SPINNER_WIDTH = 4;
+
+/** Keep rewritten TTY progress on one visual row so long status text cannot wrap and flood the terminal. */
+export function clipInteractiveProgressText(text: string, columns: number): string {
+  const budget = Math.max(
+    16,
+    (Number.isFinite(columns) ? Math.floor(columns) : 80) - INTERACTIVE_PROGRESS_SPINNER_WIDTH,
+  );
+  const characters = Array.from(text);
+  if (characters.length <= budget) return text;
+  return `${characters.slice(0, Math.max(1, budget - 1)).join('')}…`;
+}
+
+export function withProgressLine<A, E, R>(
+  initial: string,
+  use: (update: (message: string) => Effect.Effect<void>) => Effect.Effect<A, E, R>,
+) {
+  return Effect.acquireUseRelease(
+    startProgress(initial),
+    progress => use(message => progress.update(message).pipe(Effect.ignore)),
+    progress => progress.stop.pipe(Effect.ignore),
+  );
+}
+
 interface LineProgressState {
   readonly family: string;
   readonly lastEmittedAtMilliseconds: number;
@@ -251,15 +275,27 @@ export const startProgress = Effect.fn('cliUi.startProgress')(function* (message
   const render = Effect.all([
     Ref.getAndUpdate(frameIndex, index => (index + 1) % frames.length),
     Ref.get(currentMessage),
+    terminal.columns.pipe(Effect.orElseSucceed(() => 80)),
   ]).pipe(
-    Effect.flatMap(([index, text]) =>
-      flush.pipe(Effect.andThen(terminal.display(`\r\u001b[2K${muted(frames[index])} ${text}`))),
+    Effect.flatMap(([index, text, columns]) =>
+      flush.pipe(
+        Effect.andThen(
+          terminal.display(
+            `\r\u001b[2K${muted(frames[index])} ${clipInteractiveProgressText(text, Number.isFinite(columns) ? columns : 80)}`,
+          ),
+        ),
+      ),
     ),
   );
   yield* render;
   const fiber = yield* render.pipe(Effect.repeat(Schedule.spaced(100)), Effect.forkDetach);
   return {
-    update: (nextMessage: string) => Ref.set(currentMessage, nextMessage).pipe(Effect.andThen(render)),
+    update: (nextMessage: string) =>
+      Ref.get(currentMessage).pipe(
+        Effect.flatMap(current =>
+          current === nextMessage ? Effect.void : Ref.set(currentMessage, nextMessage).pipe(Effect.andThen(render)),
+        ),
+      ),
     stop: Fiber.interrupt(fiber).pipe(Effect.andThen(flush), Effect.andThen(terminal.display('\r\u001b[2K'))),
   };
 });

--- a/src/cli_ui.ts
+++ b/src/cli_ui.ts
@@ -174,13 +174,12 @@ const INTERACTIVE_PROGRESS_SPINNER_WIDTH = 4;
 
 /** Keep rewritten TTY progress on one visual row so long status text cannot wrap and flood the terminal. */
 export function clipInteractiveProgressText(text: string, columns: number): string {
-  const budget = Math.max(
-    16,
-    (Number.isFinite(columns) ? Math.floor(columns) : 80) - INTERACTIVE_PROGRESS_SPINNER_WIDTH,
-  );
+  const width = Number.isFinite(columns) && columns > 0 ? Math.floor(columns) : 80;
+  const budget = Math.max(1, width - INTERACTIVE_PROGRESS_SPINNER_WIDTH);
   const characters = Array.from(text);
   if (characters.length <= budget) return text;
-  return `${characters.slice(0, Math.max(1, budget - 1)).join('')}…`;
+  if (budget <= 1) return '…';
+  return `${characters.slice(0, budget - 1).join('')}…`;
 }
 
 export function withProgressLine<A, E, R>(

--- a/src/code_graph/build_status.ts
+++ b/src/code_graph/build_status.ts
@@ -9,6 +9,7 @@ import {
   CODE_GRAPH_BUILD_HASH_ID as HASH_ID,
   CODE_GRAPH_BUILD_ID as BUILD_ID,
   CODE_GRAPH_BUILD_STATUS_SCHEMA_VERSION,
+  codeGraphFailedBuildStatusRemovable,
   isBuildStatusRecord as isRecord,
   isBuildStatusText as isText,
 } from './build_status_validation.js';
@@ -575,9 +576,9 @@ export function codeGraphBuildHistoryInventory(page: {
 }
 
 /**
- * Inspect one bounded history page and remove at most one exact terminal or
- * abandoned status/context pair. Progress cursors let ordinary maintenance
- * advance when a page contains no safe candidate.
+ * Inspect one bounded history page and remove at most one exact terminal,
+ * expired-failed, or abandoned status/context pair. Progress cursors let
+ * ordinary maintenance advance when a page contains no safe candidate.
  */
 export const pruneCodeGraphBuildHistoryUnit = Effect.fn('codeGraph.buildStatus.pruneHistoryUnit')(function* (
   layout: CodeGraphLayout,
@@ -619,7 +620,8 @@ export const pruneCodeGraphBuildHistoryUnit = Effect.fn('codeGraph.buildStatus.p
 
 /**
  * Run one cursor-backed history page without requiring a successor reporter.
- * Ordinary maintenance uses this to converge abandoned nonterminal sidecars.
+ * Ordinary maintenance uses this to converge abandoned nonterminal sidecars
+ * and expired failed receipts.
  */
 export const maintainCodeGraphBuildHistoryUnit = Effect.fn('codeGraph.buildStatus.maintainHistoryUnit')(function* (
   layout: CodeGraphLayout,
@@ -1369,6 +1371,9 @@ const pruneCodeGraphBuildHistoryUnitWithServices = Effect.fn('codeGraph.buildSta
               protectedBuildId,
             ),
           );
+  const expiredFailed = [...ranked]
+    .reverse()
+    .find(observed => codeGraphFailedBuildStatusRemovable(observed.status, protectedBuildId));
   const terminal =
     statusNames.length <= STATUS_HISTORY_PER_WORKTREE
       ? undefined
@@ -1380,7 +1385,7 @@ const pruneCodeGraphBuildHistoryUnitWithServices = Effect.fn('codeGraph.buildSta
               observed.status.buildId !== protectedBuildId &&
               (observed.status.state === 'completed' || observed.status.state === 'failed'),
           );
-  const selected = abandoned ?? terminal;
+  const selected = abandoned ?? expiredFailed ?? terminal;
   if (selected === undefined) {
     const hasMore = remainingNames.length > pageNames.length;
     const lastBuildId = pageNames.at(-1)?.slice(0, -'.json'.length);

--- a/src/code_graph/build_status_validation.ts
+++ b/src/code_graph/build_status_validation.ts
@@ -3,6 +3,40 @@ export const CODE_GRAPH_BUILD_STATUS_SCHEMA_VERSION = 1 as const;
 export const CODE_GRAPH_BUILD_HASH_ID = /^[0-9a-f]{64}$/;
 export const CODE_GRAPH_BUILD_ID = /^[0-9a-f-]{16,64}$/;
 export const CODE_GRAPH_BUILD_COMMIT_ID = /^[0-9a-f]{7,64}$/;
+/** Failed receipts stay visible until this age, then Manager and history prune retire them. */
+export const CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS = 60 * 60 * 1_000;
+
+/** Keep a failed Manager card only while its observed heartbeat age is finite and within retention. */
+export function codeGraphFailedBuildStatusCurrent(heartbeatAgeMilliseconds: number): boolean {
+  return (
+    Number.isFinite(heartbeatAgeMilliseconds) &&
+    heartbeatAgeMilliseconds <= CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS
+  );
+}
+
+/** History prune may delete a failed receipt only after a finite observed age exceeds retention. */
+export function codeGraphFailedBuildStatusExpired(heartbeatAgeMilliseconds: number): boolean {
+  return (
+    Number.isFinite(heartbeatAgeMilliseconds) &&
+    heartbeatAgeMilliseconds > CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS
+  );
+}
+
+/** @internal Pure retention boundary for expired failed receipts. Age is history policy, not live-owner authority. */
+export function codeGraphFailedBuildStatusRemovable(
+  status: {
+    readonly buildId: string;
+    readonly observation: {readonly heartbeatAgeMilliseconds: number};
+    readonly state: string;
+  },
+  protectedBuildId?: string,
+): boolean {
+  return (
+    status.state === 'failed' &&
+    status.buildId !== protectedBuildId &&
+    codeGraphFailedBuildStatusExpired(status.observation.heartbeatAgeMilliseconds)
+  );
+}
 
 export function isBuildStatusRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/src/code_graph/cli_progress.ts
+++ b/src/code_graph/cli_progress.ts
@@ -53,6 +53,18 @@ export function formatCodeGraphIndexProgressLine(progress: CodeGraphProgress, re
   }
 }
 
+export function formatCodeGraphDoctorProgressLine(progress: CodeGraphRepairProgressLine): string {
+  const database = `${progress.current}/${progress.total} databases`;
+  switch (progress.phase) {
+    case 'checking':
+      return `Checking · checking ${database}`;
+    case 'deferred':
+      return `Checking · deferred ${database}`;
+    default:
+      return `Checking · ${progress.phase.replaceAll('-', ' ')} · ${database}`;
+  }
+}
+
 export function formatCodeGraphRepairProgressLine(progress: CodeGraphRepairProgressLine, dryRun = false): string {
   const prefix = dryRun ? 'Would repair' : 'Repairing';
   const database = `${progress.current}/${progress.total} databases`;

--- a/src/code_graph/cli_progress.ts
+++ b/src/code_graph/cli_progress.ts
@@ -1,0 +1,176 @@
+import {Clock, Effect, Option, Ref, Semaphore} from 'effect';
+import {materializationStorageShortfalls} from './indexer_materialization.js';
+import {codeGraphEtaMeasurement, makeCodeGraphEtaTracker, observeCodeGraphEta} from './progress_eta.js';
+import {formatCodeGraphStatusDuration} from './status_render.js';
+import type {CodeGraphProgress} from './types.js';
+
+interface CodeGraphRepairProgressLine {
+  readonly current: number;
+  readonly phase:
+    'checking' | 'cleaning-snapshots' | 'cleaning-vectors' | 'deferred' | 'discarding' | 'migrating-schema';
+  readonly total: number;
+}
+
+export function formatCodeGraphIndexProgressLine(progress: CodeGraphProgress, remainingMilliseconds?: number): string {
+  const eta = formatEtaSuffix(remainingMilliseconds);
+  switch (progress.phase) {
+    case 'registering':
+      return `Registering${eta}`;
+    case 'waiting':
+      return `${waitingProgressLabel(progress.reason)}${eta}`;
+    case 'scanning':
+      return `Scanning · ${countProgress(progress.completed, progress.total)} files${eta}`;
+    case 'materializing': {
+      const disk =
+        progress.metrics?.storage === undefined
+          ? ''
+          : materializationStorageShortfalls(progress.metrics.storage).length > 0
+            ? ' · low disk'
+            : '';
+      return `Materializing · ${countProgress(progress.completed, progress.total)} files${disk}${eta}`;
+    }
+    case 'reclaiming':
+      return `Reclaiming · ${countProgress(progress.completed, progress.total)} snapshots${eta}`;
+    case 'resolving':
+      if (progress.subphase === 'complete') {
+        return `Resolved · ${progress.symbols.toLocaleString()} symbols`;
+      }
+      if (progress.activity) {
+        return `Resolving · ${countProgress(progress.activity.referencesCompleted, progress.activity.referencesTotal)} references${eta}`;
+      }
+      return 'Resolving references';
+    case 'embedding':
+      return `Embedding · ${countProgress(Math.min(progress.total, progress.embedded + progress.reused), progress.total)}${eta}`;
+    case 'sharing':
+      return {
+        'applying-deltas': 'Applying shared checkpoint',
+        'building-local-overlay': 'Building local overlay',
+        'discovering-shared-base': 'Discovering shared base',
+        'downloading-checkpoint': 'Downloading shared checkpoint',
+      }[progress.subphase];
+    case 'activating':
+      return progress.activity ? `Activating · ${progress.activity.stage.replaceAll('-', ' ')}` : 'Activating snapshot';
+  }
+}
+
+export function formatCodeGraphRepairProgressLine(progress: CodeGraphRepairProgressLine, dryRun = false): string {
+  const prefix = dryRun ? 'Would repair' : 'Repairing';
+  const database = `${progress.current}/${progress.total} databases`;
+  switch (progress.phase) {
+    case 'checking':
+      return `${prefix} · checking ${database}`;
+    case 'migrating-schema':
+      return `${prefix} · migrating schema · ${database}`;
+    case 'cleaning-snapshots':
+      return `${prefix} · cleaning snapshots · ${database}`;
+    case 'cleaning-vectors':
+      return `${prefix} · cleaning temporary files · ${database}`;
+    case 'discarding':
+      return `${prefix} · discarding store · ${database}`;
+    case 'deferred':
+      return `${prefix} · deferred ${database}`;
+  }
+}
+
+export type CodeGraphCliPurgePhase =
+  'acquiring-gates' | 'deleting' | 'quarantining' | 'removing-obsolete' | 'verifying' | 'waiting-builders';
+
+export interface CodeGraphCliPurgeProgress {
+  readonly checkoutCurrent?: number;
+  readonly checkoutTotal?: number;
+  readonly dryRun?: boolean;
+  readonly filesRemoved?: number;
+  readonly filesTotal?: number;
+  readonly phase: CodeGraphCliPurgePhase;
+}
+
+export function formatCodeGraphPurgeProgressLine(progress: CodeGraphCliPurgeProgress): string {
+  const prefix = progress.dryRun === true ? 'Would purge' : 'Purging';
+  const checkout =
+    progress.checkoutCurrent !== undefined && progress.checkoutTotal !== undefined
+      ? ` · ${progress.checkoutCurrent}/${progress.checkoutTotal} checkouts`
+      : '';
+  const files =
+    progress.filesRemoved !== undefined && progress.filesTotal !== undefined
+      ? ` · ${countProgress(progress.filesRemoved, progress.filesTotal)} files`
+      : progress.filesRemoved !== undefined
+        ? ` · ${progress.filesRemoved.toLocaleString()} files`
+        : '';
+  return `${prefix} · ${purgePhaseLabel(progress.phase)}${checkout}${files}`;
+}
+
+export function formatCodeGraphCompactProgressLine(phase: 'inspecting' | 'waiting-builders' | 'compacting'): string {
+  switch (phase) {
+    case 'inspecting':
+      return 'Compacting · inspecting storage';
+    case 'waiting-builders':
+      return 'Compacting · waiting for builders';
+    case 'compacting':
+      return 'Compacting · vacuuming database';
+  }
+}
+
+export const makeCodeGraphHumanProgressReporter = Effect.fn('codeGraph.command.makeHumanProgressReporter')(
+  function* () {
+    const tracker = yield* Ref.make(makeCodeGraphEtaTracker());
+    const gate = yield* Semaphore.make(1);
+    return (progress: CodeGraphProgress) =>
+      gate.withPermit(
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
+          const observed = observeCodeGraphEta(yield* Ref.get(tracker), codeGraphEtaMeasurement(progress), now);
+          yield* Ref.set(tracker, observed.tracker);
+          return formatCodeGraphIndexProgressLine(
+            progress,
+            Option.getOrUndefined(observed.estimate)?.remainingMilliseconds,
+          );
+        }),
+      );
+  },
+);
+
+export function countProgress(completed: number, total: number): string {
+  const safeTotal = Number.isFinite(total) && total > 0 ? total : 0;
+  const safeCompleted = Number.isFinite(completed) ? Math.max(0, completed) : 0;
+  const percent = safeTotal === 0 ? 100 : Math.min(100, Math.round((safeCompleted / safeTotal) * 100));
+  return `${safeCompleted.toLocaleString()}/${safeTotal.toLocaleString()} (${percent}%)`;
+}
+
+function formatEtaSuffix(remainingMilliseconds: number | undefined): string {
+  if (remainingMilliseconds === undefined || !Number.isFinite(remainingMilliseconds) || remainingMilliseconds < 0) {
+    return '';
+  }
+  return ` · ETA ${formatCodeGraphStatusDuration(remainingMilliseconds)}`;
+}
+
+function waitingProgressLabel(reason: Extract<CodeGraphProgress, {readonly phase: 'waiting'}>['reason']): string {
+  switch (reason) {
+    case 'database-writer':
+      return 'Waiting for database writer';
+    case 'home-builder-cap':
+      return 'Waiting for builder cap';
+    case 'request-lock':
+      return 'Waiting for matching request';
+    case 'snapshot-build':
+      return 'Waiting for snapshot build';
+    default:
+      return 'Waiting for another build';
+  }
+}
+
+function purgePhaseLabel(phase: CodeGraphCliPurgePhase): string {
+  switch (phase) {
+    case 'acquiring-gates':
+      return 'acquiring locks';
+    case 'waiting-builders':
+      return 'waiting for builders';
+    case 'verifying':
+      return 'verifying checkout';
+    case 'quarantining':
+      return 'quarantining files';
+    case 'deleting':
+      return 'deleting files';
+    case 'removing-obsolete':
+      return 'removing obsolete stores';
+  }
+}

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -1,10 +1,16 @@
 import {Clock, Console, Crypto, Effect, FileSystem, Option, Path, Schema} from 'effect';
-import {startProgress} from '../cli_ui.js';
+import {startProgress, withProgressLine} from '../cli_ui.js';
 import {writeFinalCliOutput} from '../effect/cli_output.js';
 import {SystemInfo} from '../effect/system.js';
 import {healAnchorsAfterGraphIndex, healAnchorsAfterWorksetPrepare} from '../memory/deferred_code_anchor_recovery.js';
 import type {RuntimeConfig} from '../types.js';
-import {CodeGraphIndexer, materializationStorageShortfalls} from './indexer.js';
+import {CodeGraphIndexer} from './indexer.js';
+import {
+  formatCodeGraphCompactProgressLine,
+  formatCodeGraphPurgeProgressLine,
+  formatCodeGraphRepairProgressLine,
+  makeCodeGraphHumanProgressReporter,
+} from './cli_progress.js';
 import {makeCodeGraphJsonProgressReporter} from './json_progress.js';
 import {codeGraphLayout} from './layout.js';
 import {CodeGraphMaintenanceCoordinator} from './maintenance_coordinator.js';
@@ -14,7 +20,6 @@ import {
   purgeAllCodeGraphIndexes,
   purgeCodeGraphIndex,
   purgeObsoleteCodeGraphStores,
-  type CodeGraphMaintenanceProgress,
   type CodeGraphRepairCompletion,
   type ObsoleteCodeGraphStoreInventory,
 } from './maintenance.js';
@@ -22,11 +27,11 @@ import {CodeGraphQueryService, observationFromCodeGraphStatus, renderCodeGraphRe
 import {repositoryChangesSince, repositoryIdentityMatchesExpectation, resolveRepositoryIdentity} from './repository.js';
 import {CodeGraphStore} from './store.js';
 import type {
+  CodeGraphOverlayFallbackAssessment,
+  CodeGraphOverlayFallbackBoundary,
   CodeGraphProgress,
   CodeGraphQueryOptions,
   CodeGraphStatus,
-  CodeGraphOverlayFallbackBoundary,
-  CodeGraphOverlayFallbackAssessment,
   RepositoryIdentityExpectation,
 } from './types.js';
 import {CodeGraphWatcher} from './watcher.js';
@@ -70,6 +75,7 @@ import {
   type CodeGraphCliReadPlan,
 } from './cli_freshness.js';
 import {exportCodeGraph, type CodeGraphExportFormat, type CodeGraphExportLimit} from './export.js';
+import {materializationStorageShortfalls} from './indexer_materialization.js';
 import {readCodeGraphBuildStatuses, selectCodeGraphBuildStatuses} from './build_status.js';
 import {compactCodeGraphStorage, inspectCodeGraphStorage, type CodeGraphStorage} from './storage.js';
 import {resolveCodeGraphStatusOptions, serializeCodeGraphStatusV5} from './status_projection.js';
@@ -212,15 +218,25 @@ export const runCodeGraphRepair = Effect.fn('codeGraph.command.repair')(function
     ? undefined
     : (options.checkoutId ?? (yield* resolveRepositoryIdentity(yield* commandCwd(options.cwd))).checkoutId);
   let completion: CodeGraphRepairCompletion | undefined;
-  const summary = yield* repairCodeGraphIndexes(
-    config.agentContextHome,
-    options.dryRun === true,
-    options.json
-      ? undefined
-      : progress => Console.log(codeGraphRepairProgressMessage(progress, options.dryRun === true)),
-    result => Effect.sync(() => void (completion = result)),
-    {migrateSchema: true, mode: options.deep ? 'deep' : 'quick', targetCheckoutId},
-  );
+  const summary = options.json
+    ? yield* repairCodeGraphIndexes(
+        config.agentContextHome,
+        options.dryRun === true,
+        undefined,
+        result => Effect.sync(() => void (completion = result)),
+        {migrateSchema: true, mode: options.deep ? 'deep' : 'quick', targetCheckoutId},
+      )
+    : yield* withProgressLine(
+        formatCodeGraphRepairProgressLine({current: 0, phase: 'checking', total: 1}, options.dryRun === true),
+        update =>
+          repairCodeGraphIndexes(
+            config.agentContextHome,
+            options.dryRun === true,
+            progress => update(formatCodeGraphRepairProgressLine(progress, options.dryRun === true)),
+            result => Effect.sync(() => void (completion = result)),
+            {migrateSchema: true, mode: options.deep ? 'deep' : 'quick', targetCheckoutId},
+          ),
+      );
   if (options.json) {
     yield* writeFinalCliOutput(
       JSON.stringify({
@@ -264,30 +280,6 @@ export const runCodeGraphDiagnostics = Effect.fn('codeGraph.command.diagnostics'
   });
   yield* writeFinalCliOutput(options.json ? JSON.stringify(report) : renderCodeGraphDiagnostics(report).trimEnd());
 });
-
-function codeGraphRepairProgressMessage(progress: CodeGraphMaintenanceProgress, dryRun: boolean): string {
-  const database = `native code graph database ${progress.current}/${progress.total}`;
-  switch (progress.phase) {
-    case 'checking':
-      return `Checking ${database}.`;
-    case 'migrating-schema':
-      return `${dryRun ? 'Would migrate' : 'Migrating'} the persistent schema for ${database}.`;
-    case 'cleaning-snapshots':
-      return `${dryRun ? 'Would clean' : 'Cleaning'} ${progress.snapshots ?? 0} incomplete snapshot(s) from ${database}.`;
-    case 'cleaning-vectors':
-      return `Checking temporary graph state for ${database}.`;
-    case 'discarding':
-      return `${dryRun ? 'Would discard' : 'Discarding'} unreadable derived ${database}.`;
-    case 'deferred':
-      if (progress.reason === 'active-build') {
-        return `Deferred ${database}: an active graph build owns the checkout.`;
-      }
-      if (progress.reason === 'schema-upgrade-on-use') {
-        return `Deferred ${database}: ready snapshots remain usable while background schema migration retries.`;
-      }
-      return `Deferred ${database}: rerun with --deep when a full derived-store check is convenient.`;
-  }
-}
 
 interface CodeGraphExportTemporaryIdentity {
   readonly birthtimeMilliseconds: number;
@@ -763,29 +755,25 @@ export const runCodeGraphIndex = Effect.fn('codeGraph.command.index')(function* 
     return;
   }
   yield* Console.log(`Indexing code graph: ${identity.displayName}`);
-  const summary = yield* Effect.acquireUseRelease(
-    startProgress('Scanning repository source from Git.'),
-    progress =>
-      indexer
-        .index({
-          cwd,
-          ...(ensureVectors === false ? {ensureVectors: false} : {}),
-          ...(options.expectedIdentity ? {expectedIdentity: options.expectedIdentity} : {}),
-          force: options.full,
-          onProgress: state => progress.update(progressMessage(state)).pipe(Effect.ignore),
-          threadnoteHome: config.agentContextHome,
-        })
-        .pipe(
-          Effect.tap(summary =>
-            progress
-              .update(
-                `Ready · ${summary.snapshot.fileCount} files · ${summary.snapshot.symbolCount} symbols · ` +
-                  `${summary.snapshot.edgeCount} edges`,
-              )
-              .pipe(Effect.ignore),
+  const formatProgress = yield* makeCodeGraphHumanProgressReporter();
+  const summary = yield* withProgressLine('Scanning repository source from Git.', update =>
+    indexer
+      .index({
+        cwd,
+        ...(ensureVectors === false ? {ensureVectors: false} : {}),
+        ...(options.expectedIdentity ? {expectedIdentity: options.expectedIdentity} : {}),
+        force: options.full,
+        onProgress: state => formatProgress(state).pipe(Effect.flatMap(update)),
+        threadnoteHome: config.agentContextHome,
+      })
+      .pipe(
+        Effect.tap(summary =>
+          update(
+            `Ready · ${summary.snapshot.fileCount} files · ${summary.snapshot.symbolCount} symbols · ` +
+              `${summary.snapshot.edgeCount} edges`,
           ),
         ),
-    progress => progress.stop.pipe(Effect.ignore),
+      ),
   );
   yield* healAnchorsAfterGraphIndex(config, cwd, summary.identity);
   yield* Console.log(
@@ -1121,13 +1109,12 @@ export const runCodeGraphInspect = Effect.fn('codeGraph.command.inspect')(functi
       threadnoteHome: config.agentContextHome,
     });
   const reportProgress = effectiveOptions.json ? yield* makeCodeGraphJsonProgressReporter() : undefined;
+  const formatProgress = effectiveOptions.json ? undefined : yield* makeCodeGraphHumanProgressReporter();
   const read = effectiveOptions.json
     ? inspect(reportProgress)
     : readPlan.refresh
-      ? Effect.acquireUseRelease(
-          startProgress('Scanning repository source from Git.'),
-          progress => inspect(state => progress.update(progressMessage(state)).pipe(Effect.ignore)),
-          progress => progress.stop.pipe(Effect.ignore),
+      ? withProgressLine('Scanning repository source from Git.', update =>
+          inspect(state => formatProgress!(state).pipe(Effect.flatMap(update))),
         )
       : inspect();
   const readTimeoutMilliseconds = options.readTimeoutMilliseconds ?? CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS;
@@ -1273,16 +1260,25 @@ export const runCodeGraphPurge = Effect.fn('codeGraph.command.purge')(function* 
     if (options.obsolete || options.all || options.dryRun) {
       return yield* CodeGraphCommandError.make({message: 'Use --snapshot-id without --all, --obsolete, or --dry-run.'});
     }
+    const snapshotId = options.snapshotId;
     let checkoutId = options.checkoutId;
     if (checkoutId === undefined) {
       const cwd = yield* commandCwd(options.cwd);
       checkoutId = (yield* resolveRepositoryIdentity(cwd)).checkoutId;
     }
-    const result = yield* purgeCodeGraphSnapshot(
-      config.agentContextHome,
-      {checkoutId, snapshotId: options.snapshotId},
-      {apply: options.apply === true, approvalDigest: options.approval},
-    );
+    const result = options.json
+      ? yield* purgeCodeGraphSnapshot(
+          config.agentContextHome,
+          {checkoutId, snapshotId},
+          {apply: options.apply === true, approvalDigest: options.approval},
+        )
+      : yield* withProgressLine(formatCodeGraphPurgeProgressLine({phase: 'acquiring-gates'}), () =>
+          purgeCodeGraphSnapshot(
+            config.agentContextHome,
+            {checkoutId, snapshotId},
+            {apply: options.apply === true, approvalDigest: options.approval},
+          ),
+        );
     yield* writeFinalCliOutput(
       options.json ? serializeCodeGraphSnapshotPurgeResult(result) : renderCodeGraphSnapshotPurgeResult(result),
     );
@@ -1299,9 +1295,15 @@ export const runCodeGraphPurge = Effect.fn('codeGraph.command.purge')(function* 
       const cwd = yield* commandCwd(options.cwd);
       checkoutId = (yield* resolveRepositoryIdentity(cwd)).checkoutId;
     }
-    const summary = yield* purgeObsoleteCodeGraphStores(config.agentContextHome, checkoutId, {
-      dryRun: options.dryRun === true,
-    });
+    const targetCheckoutId = checkoutId;
+    const summary = yield* withProgressLine(
+      formatCodeGraphPurgeProgressLine({dryRun: options.dryRun === true, phase: 'acquiring-gates'}),
+      update =>
+        purgeObsoleteCodeGraphStores(config.agentContextHome, targetCheckoutId, {
+          dryRun: options.dryRun === true,
+          onProgress: progress => update(formatCodeGraphPurgeProgressLine(progress)),
+        }),
+    );
     const action = options.dryRun ? 'Would remove' : 'Removed';
     yield* Console.log(
       `${action} ${summary.fileCount} verified obsolete code graph file(s), ${summary.bytes} byte(s), ` +
@@ -1317,15 +1319,23 @@ export const runCodeGraphPurge = Effect.fn('codeGraph.command.purge')(function* 
       yield* Console.log(`Would remove derived code graph indexes: ${root}`);
       return;
     }
-    const removed = yield* purgeAllCodeGraphIndexes(config.agentContextHome);
+    const removed = yield* withProgressLine(formatCodeGraphPurgeProgressLine({phase: 'acquiring-gates'}), update =>
+      purgeAllCodeGraphIndexes(config.agentContextHome, progress => update(formatCodeGraphPurgeProgressLine(progress))),
+    );
     yield* Console.log(`Removed derived code graph indexes: ${removed}`);
     return;
   }
   if (options.checkoutId !== undefined) {
-    const summary = yield* purgeCodeGraphIndex(config.agentContextHome, options.checkoutId, {
-      dryRun: options.dryRun === true,
-      waitTimeoutMilliseconds: options.waitTimeoutMilliseconds,
-    });
+    const checkoutId = options.checkoutId;
+    const summary = yield* withProgressLine(
+      formatCodeGraphPurgeProgressLine({dryRun: options.dryRun === true, phase: 'acquiring-gates'}),
+      update =>
+        purgeCodeGraphIndex(config.agentContextHome, checkoutId, {
+          dryRun: options.dryRun === true,
+          onProgress: progress => update(formatCodeGraphPurgeProgressLine(progress)),
+          waitTimeoutMilliseconds: options.waitTimeoutMilliseconds,
+        }),
+    );
     if (!summary.existed) {
       yield* Console.log(`No derived code graph index exists for checkout ${summary.checkoutId.slice(0, 12)}.`);
       return;
@@ -1342,7 +1352,9 @@ export const runCodeGraphPurge = Effect.fn('codeGraph.command.purge')(function* 
     yield* Console.log(`Would remove derived code graph indexes: ${path.dirname(status.databasePath)}`);
     return;
   }
-  const repositoryRoot = yield* service.purge(config.agentContextHome, cwd);
+  const repositoryRoot = yield* withProgressLine(formatCodeGraphPurgeProgressLine({phase: 'acquiring-gates'}), update =>
+    service.purge(config.agentContextHome, cwd, progress => update(formatCodeGraphPurgeProgressLine(progress))),
+  );
   yield* Console.log(`Removed derived code graph indexes: ${repositoryRoot}`);
 });
 
@@ -1398,10 +1410,18 @@ export const runCodeGraphCompact = Effect.fn('codeGraph.command.compact')(functi
       message: 'Repository identity does not match the requested graph target.',
     });
   }
-  const summary = yield* compactCodeGraphStorage(config.agentContextHome, identity.checkoutId, {
-    dryRun: options.dryRun === true,
-    force: options.force,
-  });
+  const summary = options.json
+    ? yield* compactCodeGraphStorage(config.agentContextHome, identity.checkoutId, {
+        dryRun: options.dryRun === true,
+        force: options.force,
+      })
+    : yield* withProgressLine(formatCodeGraphCompactProgressLine('inspecting'), update =>
+        compactCodeGraphStorage(config.agentContextHome, identity.checkoutId, {
+          dryRun: options.dryRun === true,
+          force: options.force,
+          onProgress: phase => update(formatCodeGraphCompactProgressLine(phase)),
+        }),
+      );
   if (options.json) {
     yield* writeFinalCliOutput(JSON.stringify({type: 'code-graph-compaction', version: 1, ...summary}));
     return;
@@ -1688,150 +1708,20 @@ const ensureAnalysisSnapshot = Effect.fn('codeGraph.command.ensureAnalysisSnapsh
               threadnoteHome: config.agentContextHome,
             });
           })
-        : Effect.acquireUseRelease(
-            startProgress('Refreshing repository graph before analysis.'),
-            progress =>
+        : Effect.gen(function* () {
+            const formatProgress = yield* makeCodeGraphHumanProgressReporter();
+            yield* withProgressLine('Refreshing repository graph before analysis.', update =>
               indexer.index({
                 cwd,
                 ensureVectors: false,
-                onProgress: state => progress.update(progressMessage(state)).pipe(Effect.ignore),
+                onProgress: state => formatProgress(state).pipe(Effect.flatMap(update)),
                 threadnoteHome: config.agentContextHome,
               }),
-            progress => progress.stop.pipe(Effect.ignore),
-          ),
+            );
+          }),
     {operation, readTimeoutMilliseconds},
   );
 });
-
-function progressMessage(progress: CodeGraphProgress): string {
-  switch (progress.phase) {
-    case 'registering':
-      return 'Registering repository index';
-    case 'waiting':
-      switch (progress.reason) {
-        case 'database-writer':
-          return 'Waiting for the code graph database writer';
-        case 'home-builder-cap':
-          return 'Waiting for the home code graph builder cap';
-        case 'request-lock':
-          return 'Waiting for the matching code graph request';
-        case 'snapshot-build':
-          return 'Waiting for the matching code graph snapshot build';
-        case 'repository-lock':
-          return 'Waiting for another code graph build to finish';
-        default:
-          return 'Waiting for another code graph build to finish';
-      }
-    case 'scanning': {
-      const summary =
-        `Scanning · ${progress.completed}/${progress.total} eligible files · ${progress.accepted} accepted · ` +
-        `${progress.skipped} content skipped · ${progress.excluded} excluded`;
-      if (!progress.activity) return summary;
-      const activity = progress.activity;
-      const timing = [
-        activity.parseMilliseconds === undefined
-          ? undefined
-          : `parse ${formatMilliseconds(activity.parseMilliseconds)}`,
-        activity.persistMilliseconds === undefined
-          ? undefined
-          : `persist ${formatMilliseconds(activity.persistMilliseconds)}`,
-      ].filter((value): value is string => value !== undefined);
-      const activityLabel =
-        activity.stage === 'reading'
-          ? `reading Git batch from ${activity.path}`
-          : activity.stage === 'persisting'
-            ? `persisting batch from ${activity.path}`
-            : `${activity.stage} ${activity.path}`;
-      return (
-        `${summary} · ${activityLabel} · ${activity.language} · ${formatBytes(activity.bytes)} · ` +
-        `batch ${activity.batchCompleted}/${activity.batchTotal}` +
-        (activity.degraded ? ' · metadata fallback' : '') +
-        (timing.length > 0 ? ` · ${timing.join(' · ')}` : '')
-      );
-    }
-    case 'materializing':
-      return materializationProgressMessage(progress);
-    case 'reclaiming':
-      return (
-        `Reclaiming superseded graph storage · ${progress.completed}/${progress.total} snapshots · ` +
-        `${progress.pagesCompleted.toLocaleString()} pages · ${progress.rowsDeleted.toLocaleString()} rows`
-      );
-    case 'resolving':
-      if (progress.subphase === 'complete') {
-        return `Resolved · ${progress.symbols} symbols · ${progress.edges} relationships · ${progress.resolved} references linked`;
-      }
-      if (!progress.activity) return 'Resolving references · preparing pass totals';
-      return (
-        `Resolving references · pass ${progress.activity.pass} · ` +
-        `page ${progress.activity.pageCompleted}/${progress.activity.pageTotal} · ` +
-        `${progress.activity.referencesCompleted}/${progress.activity.referencesTotal} references · ` +
-        `${progress.activity.resolved} linked · ${progress.activity.referencesExamined} cumulative examined · ` +
-        `match ${formatMilliseconds(progress.activity.matchingMilliseconds)} · ` +
-        `transactions ${formatMilliseconds(progress.activity.transactionMilliseconds)} · ` +
-        `elapsed ${formatMilliseconds(progress.activity.elapsedMilliseconds)}`
-      );
-    case 'embedding':
-      return (
-        `Embedding · ${Math.min(progress.total, progress.embedded + progress.reused)}/${progress.total} complete · ` +
-        `${progress.reused} reused`
-      );
-    case 'sharing':
-      return {
-        'applying-deltas': 'Applying shared graph checkpoint',
-        'building-local-overlay': 'Building local overlay on the shared graph base',
-        'discovering-shared-base': 'Discovering shared graph base',
-        'downloading-checkpoint': 'Downloading shared graph checkpoint',
-      }[progress.subphase];
-    case 'activating': {
-      if (progress.activity) {
-        const activity = progress.activity;
-        const rows = activity.rows === undefined ? '' : ` · ${activity.rows.toLocaleString()} rows`;
-        const transaction =
-          activity.transactionMilliseconds === undefined
-            ? ''
-            : ` · transaction ${formatMilliseconds(activity.transactionMilliseconds)}`;
-        return (
-          `Activating · ${activity.stage.replaceAll('-', ' ')} ${activity.state} · ` +
-          `${formatMilliseconds(activity.stageElapsedMilliseconds)}${rows}${transaction}`
-        );
-      }
-      return `Activating (${progress.subphase ?? 'snapshot'}) · ${progress.snapshotId}`;
-    }
-  }
-}
-
-function materializationProgressMessage(
-  progress: Extract<CodeGraphProgress, {readonly phase: 'materializing'}>,
-): string {
-  const plan = [
-    progress.metrics?.mode === undefined ? undefined : `${progress.metrics.mode.replaceAll('-', ' ')} materialization`,
-    progress.metrics?.fallbackReason === undefined
-      ? undefined
-      : `incremental fallback: ${progress.metrics.fallbackReason.replaceAll('-', ' ')}`,
-    renderFallbackAssessment(progress.metrics?.fallbackAssessment),
-    renderFallbackBoundary(progress.metrics?.fallbackBoundary),
-  ]
-    .filter((value): value is string => value !== undefined)
-    .join(' · ');
-  const summary = `Materializing · ${progress.completed}/${progress.total} files · ${progress.reused} reused${
-    plan ? ` · ${plan}` : ''
-  }`;
-  const diskWarning = materializationDiskWarning(progress.metrics?.storage);
-  const activity = progress.activity;
-  if (!activity) return diskWarning ? `${summary} · ${diskWarning}` : summary;
-  const details = [
-    materializationStageLabel(activity.stage),
-    `batch ${activeBatchNumber(activity.batchCompleted, activity.batchTotal)}/${activity.batchTotal}`,
-    `${formatBytes(activity.sourceBytes)} source`,
-    activity.cachedFactBytes === undefined ? undefined : `${formatBytes(activity.cachedFactBytes)} cached facts`,
-    renderMaterializationRows(activity.rows),
-    activity.elapsedMilliseconds === undefined ? undefined : formatMilliseconds(activity.elapsedMilliseconds),
-    activity.transactionMilliseconds === undefined
-      ? undefined
-      : `transaction ${formatMilliseconds(activity.transactionMilliseconds)}`,
-  ].filter((value): value is string => value !== undefined);
-  return `${summary} · ${details.join(' · ')}${diskWarning ? ` · ${diskWarning}` : ''}`;
-}
 
 function renderFallbackAssessment(assessment: CodeGraphOverlayFallbackAssessment | undefined): string | undefined {
   if (assessment === undefined) return undefined;

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -6,7 +6,6 @@ import {codeGraphCommittedContentHash} from './content_identity.js';
 import {
   inspectContainedStableRegularFile,
   materializeContainedStableRegularFile,
-  readOptionalText,
   type StableContainedRegularFileMetadata,
 } from './inventory_contained_file.js';
 import {
@@ -38,6 +37,15 @@ import {
 import {compareCodeUnits} from './ordering.js';
 import {workspaceHasUninventoriedMonikerEvidence} from './workspace.js';
 import {
+  compileThreadnoteIgnore,
+  emptyThreadnoteIgnoreAdmissionPath,
+  isIgnoredByThreadnote,
+  isOverlayAdmissionControlPath,
+  readThreadnoteIgnoreSources,
+  type CompiledIgnoreRule,
+  type ThreadnoteIgnoreSources,
+} from './threadnote_ignore.js';
+import {
   codeGraphExtractionPlanMetrics,
   codeGraphSourceSizeBucket,
   CODE_GRAPH_SCANNING_STARTED_PROGRESS,
@@ -54,6 +62,14 @@ import {CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION} from './store_models.js';
 export {codeGraphInventoryExclusionReason} from './inventory_policy.js';
 export {readContainedStableRegularFile, type ContainedReadInterlock} from './inventory_contained_file.js';
 export {shouldOmitRepositoryContent} from './inventory_content.js';
+export {
+  compileThreadnoteIgnore,
+  isIgnoredByThreadnote,
+  isOverlayAdmissionControlPath,
+  THREADNOTE_IGNORE_FILE,
+  THREADNOTE_IGNORE_LOCAL_FILE,
+  type CompiledIgnoreRule,
+} from './threadnote_ignore.js';
 export type {
   CodeGraphInventoryPolicyExclusionReasonSummary,
   CodeGraphInventoryPolicyExclusionSummary,
@@ -64,11 +80,6 @@ export interface GitTreeEntry {
   readonly mode: string;
   readonly path: string;
   readonly size: number;
-}
-
-export interface CompiledIgnoreRule {
-  readonly ignored: boolean;
-  readonly pattern: RegExp;
 }
 
 export interface CodeGraphInventory {
@@ -168,6 +179,7 @@ export interface CodeGraphInventoryPreviewSummaryOptions {
   readonly includeOpaqueCorpusAssets?: boolean;
   readonly languagePacks?: CodeGraphLanguagePackRegistryShape;
   readonly threadnoteIgnore?: string;
+  readonly threadnoteIgnoreLocal?: string;
 }
 
 export interface CodeGraphInventoryPreviewOptions {
@@ -246,7 +258,7 @@ export function summarizeCodeGraphInventoryPreview(
   options: CodeGraphInventoryPreviewSummaryOptions = {},
 ): Pick<CodeGraphInventoryPreview, 'groups' | 'policyVersion' | 'totals'> {
   const languagePacks = options.languagePacks ?? BUILTIN_LANGUAGE_PACK_REGISTRY;
-  const ignoreRules = compileThreadnoteIgnore(options.threadnoteIgnore ?? '');
+  const ignoreRules = compileThreadnoteIgnore(options.threadnoteIgnore ?? '', options.threadnoteIgnoreLocal ?? '');
   const gitIgnoredPaths = options.gitIgnoredPaths ?? new Set<string>();
   const groups = new Map<string, CodeGraphInventoryPreviewGroup>();
   let eligibleBytes = 0;
@@ -345,8 +357,10 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
   const committedTreeEntries = new Map(allTreeEntries.map(entry => [entry.path, entry]));
   const policyAdmittedTreeEntries = allTreeEntries.filter(entry => !committedPolicyExclusions.has(entry.path));
   const declaredWorkspace = yield* discoverDeclaredSourceRoots(identity, policyAdmittedTreeEntries, languagePacks);
-  const threadnoteIgnore = reuseEnvironment.threadnoteIgnore;
-  const ignoreRules = compileThreadnoteIgnore(threadnoteIgnore);
+  const ignoreRules = compileThreadnoteIgnore(
+    reuseEnvironment.threadnoteIgnore,
+    reuseEnvironment.threadnoteIgnoreLocal,
+  );
   const acceptedByPolicy = policyAdmittedTreeEntries.filter(entry =>
     acceptsRepositoryPathWithRules(
       entry.path,
@@ -417,7 +431,10 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
       : yield* readDirtyOverlay(
           identity,
           path,
-          threadnoteIgnore,
+          {
+            committed: reuseEnvironment.threadnoteIgnore,
+            local: reuseEnvironment.threadnoteIgnoreLocal,
+          },
           ignoreRules,
           options.cachedCommittedFileKeys ?? new Set(),
           languagePacks,
@@ -580,8 +597,8 @@ export const inventoryRepositoryFromReusableCleanBase = Effect.fn('codeGraph.inv
     const overlay = yield* readDirtyOverlay(
       identity,
       path,
-      environment.threadnoteIgnore,
-      compileThreadnoteIgnore(environment.threadnoteIgnore),
+      {committed: environment.threadnoteIgnore, local: environment.threadnoteIgnoreLocal},
+      compileThreadnoteIgnore(environment.threadnoteIgnore, environment.threadnoteIgnoreLocal),
       options.cachedCommittedFileKeys ?? new Set(),
       languagePacks,
       projectRoots,
@@ -653,8 +670,8 @@ export const previewCodeGraphInventory = Effect.fn('codeGraph.previewInventory')
     entry => codeGraphInventoryExclusionReason(entry.path, entry.size) === undefined,
   );
   const declaredWorkspace = yield* discoverDeclaredSourceRoots(identity, policyAdmittedEntries, languagePacks);
-  const threadnoteIgnore = yield* readOptionalText(fs, path.join(identity.repoRoot, '.threadnoteignore'));
-  const ignoreRules = compileThreadnoteIgnore(threadnoteIgnore);
+  const ignoreSources = yield* readThreadnoteIgnoreSources(fs, path, identity.repoRoot);
+  const ignoreRules = compileThreadnoteIgnore(ignoreSources.committed, ignoreSources.local);
   const tree = yield* readInventoryPreviewTree(identity, path, committedEntries, options.includeOverlay !== false);
   const threadnoteIgnoredChangedPaths = new Set(
     [...tree.changes.changed].filter(relative => isIgnoredByThreadnote(relative, ignoreRules)),
@@ -701,7 +718,8 @@ export const previewCodeGraphInventory = Effect.fn('codeGraph.previewInventory')
     gitIgnoredPaths,
     languagePacks,
     includeOpaqueCorpusAssets: options.includeOpaqueCorpusAssets,
-    threadnoteIgnore,
+    threadnoteIgnore: ignoreSources.committed,
+    threadnoteIgnoreLocal: ignoreSources.local,
   });
   return {
     commit: identity.headCommit,
@@ -856,12 +874,12 @@ export const worktreeOverlayState = Effect.fn('codeGraph.worktreeOverlayState')(
     policyAdmittedTreeEntries,
     BUILTIN_LANGUAGE_PACK_REGISTRY,
   );
-  const threadnoteIgnore = yield* readOptionalText(fs, path.join(identity.repoRoot, '.threadnoteignore'));
-  const ignoreRules = compileThreadnoteIgnore(threadnoteIgnore);
+  const ignoreSources = yield* readThreadnoteIgnoreSources(fs, path, identity.repoRoot);
+  const ignoreRules = compileThreadnoteIgnore(ignoreSources.committed, ignoreSources.local);
   const overlay = yield* readDirtyOverlay(
     identity,
     path,
-    threadnoteIgnore,
+    ignoreSources,
     ignoreRules,
     new Set(),
     BUILTIN_LANGUAGE_PACK_REGISTRY,
@@ -918,7 +936,7 @@ export const worktreeBuildRequestObservation = Effect.fn('codeGraph.worktreeBuil
     } satisfies CodeGraphBuildRequestObservation;
   }
   const overlay = parsePorcelainV1Status(porcelain.stdout);
-  const threadnoteIgnore = yield* readOptionalText(fs, path.join(identity.repoRoot, '.threadnoteignore'));
+  const ignoreSources = yield* readThreadnoteIgnoreSources(fs, path, identity.repoRoot);
   const fileRows: string[] = [];
   const observedFiles: CodeGraphObservedOverlayFile[] = [];
   const skippedRows: string[] = [];
@@ -958,7 +976,8 @@ export const worktreeBuildRequestObservation = Effect.fn('codeGraph.worktreeBuil
         ? sha256HexSync(
             [
               'build-request-overlay-v2',
-              `I\0${sha256HexSync(threadnoteIgnore)}`,
+              `I\0${sha256HexSync(ignoreSources.committed)}`,
+              `L\0${sha256HexSync(ignoreSources.local)}`,
               ...[...overlay.deleted].sort(compareCodeUnits).map(relative => `D\0${relative}`),
               ...fileRows,
               ...skippedRows,
@@ -1174,10 +1193,11 @@ export function acceptsRepositoryPath(
   threadnoteIgnore = '',
   declaredProjectRoots: readonly string[] = [],
   declaredSourceRoots: readonly string[] = [],
+  threadnoteIgnoreLocal = '',
 ): boolean {
   return acceptsRepositoryPathWithRules(
     value,
-    compileThreadnoteIgnore(threadnoteIgnore),
+    compileThreadnoteIgnore(threadnoteIgnore, threadnoteIgnoreLocal),
     BUILTIN_LANGUAGE_PACK_REGISTRY,
     declaredProjectRoots,
     declaredSourceRoots,
@@ -1207,10 +1227,6 @@ function isPotentialOverlayCandidate(value: string, languagePacks: CodeGraphLang
 
 function isInventoryPolicyExtension(repositoryPath: string): boolean {
   return /\.(?:jsonc?|svg)$/i.test(repositoryPath);
-}
-
-export function isOverlayAdmissionControlPath(repositoryPath: string): boolean {
-  return repositoryPath === '.threadnoteignore' || /(?:^|\/)\.gitignore$/.test(repositoryPath);
 }
 
 function acceptsRepositoryPathWithRules(
@@ -1270,43 +1286,6 @@ function repositoryPathExclusionReason(
   if (isIgnoredByThreadnote(path, ignoreRules)) return 'threadnote-ignore';
   if (!includeOpaqueCorpusAssets && isOpaqueCorpusMediaPath(path)) return 'opaque-corpus-deferred';
   return Option.isSome(languagePacks.match(path)) ? undefined : 'unsupported-language';
-}
-
-export function compileThreadnoteIgnore(content: string): readonly CompiledIgnoreRule[] {
-  const rules: CompiledIgnoreRule[] = [];
-  for (const rawLine of content.split(/\r?\n/)) {
-    const trimmed = rawLine.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const negated = trimmed.startsWith('!');
-    const pattern = normalizeRepositoryPath(negated ? trimmed.slice(1) : trimmed);
-    if (!pattern) continue;
-    const compiled = compileIgnorePattern(pattern);
-    if (compiled) rules.push({ignored: !negated, pattern: compiled});
-  }
-  return rules;
-}
-
-function isIgnoredByThreadnote(path: string, rules: readonly CompiledIgnoreRule[]): boolean {
-  let ignored = false;
-  for (const rule of rules) {
-    if (rule.pattern.test(path)) ignored = rule.ignored;
-  }
-  return ignored;
-}
-
-function compileIgnorePattern(pattern: string): RegExp | undefined {
-  const directoryPattern = pattern.endsWith('/');
-  const normalized = pattern.replace(/^\/+|\/+$/g, '');
-  if (!normalized) return undefined;
-  const escaped = normalized
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replaceAll('**', '\u0000')
-    .replaceAll('*', '[^/]*')
-    .replaceAll('?', '[^/]')
-    .replaceAll('\u0000', '.*');
-  const prefix = normalized.includes('/') ? '^' : '(?:^|/)';
-  const suffix = directoryPattern ? '(?:/|$)' : '$';
-  return new RegExp(`${prefix}${escaped}${suffix}`, 'i');
 }
 
 function ignoredPaths(repoRoot: string, paths: readonly string[]) {
@@ -1580,7 +1559,7 @@ export function parseGitCatFileBatch(
 export const readDirtyOverlay = Effect.fn('codeGraph.readDirtyOverlay')(function* (
   identity: RepositoryIdentity,
   path: Path.Path,
-  threadnoteIgnore: string,
+  ignoreSources: ThreadnoteIgnoreSources,
   ignoreRules: readonly CompiledIgnoreRule[],
   cachedFileKeys: ReadonlySet<string>,
   languagePacks: CodeGraphLanguagePackRegistryShape,
@@ -1710,7 +1689,7 @@ export const readDirtyOverlay = Effect.fn('codeGraph.readDirtyOverlay')(function
     skipped += 1;
     if (
       (untracked.has(relative) || changes.added.has(relative)) &&
-      (!isOverlayAdmissionControlPath(relative) || (relative === '.threadnoteignore' && threadnoteIgnore.length === 0))
+      (!isOverlayAdmissionControlPath(relative) || emptyThreadnoteIgnoreAdmissionPath(relative, ignoreSources))
     ) {
       changed.delete(relative);
       return;
@@ -1906,7 +1885,8 @@ export const readDirtyOverlay = Effect.fn('codeGraph.readDirtyOverlay')(function
     fingerprint: dirty
       ? sha256HexSync(
           [
-            `I\0${sha256HexSync(threadnoteIgnore)}`,
+            `I\0${sha256HexSync(ignoreSources.committed)}`,
+            `L\0${sha256HexSync(ignoreSources.local)}`,
             ...[...changes.deleted].sort().map(relative => `D\0${relative}`),
             ...files.map(file => `F\0${file.path}\0${file.contentHash}`).sort(),
             ...[...skippedPaths].sort().map(relative => `S\0${relative}`),

--- a/src/code_graph/inventory_reuse.ts
+++ b/src/code_graph/inventory_reuse.ts
@@ -3,6 +3,7 @@ import {sha256HexSync} from '../crypto/sha256.js';
 import {runCommandEffect} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {readOptionalText} from './inventory_contained_file.js';
+import {readThreadnoteIgnoreSources} from './threadnote_ignore.js';
 import {CodeGraphInventoryError} from './inventory_error.js';
 import {
   CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
@@ -83,7 +84,9 @@ export const readCodeGraphInventoryReuseEnvironment = Effect.fn('codeGraph.readI
   if (globalExcludeResult.exitCode !== 0 && globalExcludeResult.exitCode !== 1) {
     return yield* CodeGraphInventoryError.make({message: 'Global Git exclude policy is unavailable.'});
   }
-  const threadnoteIgnore = yield* readOptionalText(fs, path.join(identity.repoRoot, '.threadnoteignore'));
+  const ignoreSources = yield* readThreadnoteIgnoreSources(fs, path, identity.repoRoot);
+  const threadnoteIgnore = ignoreSources.committed;
+  const threadnoteIgnoreLocal = ignoreSources.local;
   const observedGitInfoExcludePath = gitInfoExcludeResult.stdout.trim();
   const gitInfoExcludePath = path.isAbsolute(observedGitInfoExcludePath)
     ? observedGitInfoExcludePath
@@ -115,11 +118,13 @@ export const readCodeGraphInventoryReuseEnvironment = Effect.fn('codeGraph.readI
       [
         'code-graph-inventory-environment-v1',
         `threadnote:${sha256HexSync(threadnoteIgnore)}`,
+        `threadnote-local:${sha256HexSync(threadnoteIgnoreLocal)}`,
         `git-info-exclude:${sha256HexSync(gitInfoExclude)}`,
         `global-exclude:${sha256HexSync(globalExclude)}`,
       ].join('\n'),
     ),
     threadnoteIgnore,
+    threadnoteIgnoreLocal,
   } as const;
 });
 

--- a/src/code_graph/inventory_sparse.ts
+++ b/src/code_graph/inventory_sparse.ts
@@ -119,8 +119,8 @@ export const inventoryRepositoryFromReusableCleanBaseSlice = Effect.fn(
   const overlay = yield* readDirtyOverlay(
     identity,
     path,
-    environment.threadnoteIgnore,
-    compileThreadnoteIgnore(environment.threadnoteIgnore),
+    {committed: environment.threadnoteIgnore, local: environment.threadnoteIgnoreLocal},
+    compileThreadnoteIgnore(environment.threadnoteIgnore, environment.threadnoteIgnoreLocal),
     options.cachedCommittedFileKeys ?? new Set(),
     languagePacks,
     projectRoots,

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -1071,7 +1071,7 @@ export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(f
             yield* publishPurgeProgress(reporter, onProgress, false, {
               checkoutCurrent: index + 1,
               checkoutTotal: repositoryIds.length,
-              completed: index,
+              completed: index + 1,
               gate: 'waiting-builders',
               phase: 'waiting-builders',
               total,
@@ -1090,7 +1090,7 @@ export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(f
                     yield* publishPurgeProgress(reporter, onProgress, false, {
                       checkoutCurrent: index + 1,
                       checkoutTotal: repositoryIds.length,
-                      completed: index,
+                      completed: index + 1,
                       gate: 'retiring-and-cleaning',
                       phase: 'deleting',
                       total,

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -12,8 +12,11 @@ import {
   codeGraphRepositoryLockActive,
   codeGraphWorktreeBuildActive,
   withCodeGraphDatabaseWriteLock,
-  withCodeGraphMaintenanceIntent,
+  withCodeGraphReportedMaintenanceIntent,
+  type CodeGraphMaintenanceProgress as CodeGraphReportedMaintenanceProgress,
+  type CodeGraphMaintenanceProgressReporter,
 } from './maintenance_gate.js';
+import type {CodeGraphCliPurgeProgress} from './cli_progress.js';
 import {CodeGraphStore, type CodeGraphDatabaseHealth} from './store.js';
 import {CODE_GRAPH_SCHEMA_VERSION} from './types.js';
 import {CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR} from './store/schema_revision.js';
@@ -121,6 +124,7 @@ export interface CodeGraphMaintenanceProgress {
 }
 
 type CodeGraphProgressHandler = (progress: CodeGraphMaintenanceProgress) => Effect.Effect<void, unknown>;
+type CodeGraphPurgeProgressHandler = (progress: CodeGraphCliPurgeProgress) => Effect.Effect<void, unknown>;
 type CodeGraphRepairCompletionHandler<R> = (completion: CodeGraphRepairCompletion) => Effect.Effect<void, unknown, R>;
 type CodeGraphQuickCheck =
   {readonly health: CodeGraphDatabaseHealth; readonly state: 'checked'} | {readonly state: 'unreadable'};
@@ -303,317 +307,330 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
   if (options.targetCheckoutId !== undefined && !/^[0-9a-f]{64}$/.test(options.targetCheckoutId)) {
     return yield* CodeGraphMaintenanceError.make({message: 'Code graph checkout identity is invalid.'});
   }
-  const repair = Effect.gen(function* () {
-    const allDatabases = yield* codeGraphDatabasePaths(threadnoteHome);
-    const allRepositoryCheckoutIds = yield* codeGraphRepositoryCheckoutIds(threadnoteHome);
-    const repositoryCheckoutIds =
-      options.targetCheckoutId === undefined
-        ? allRepositoryCheckoutIds
-        : allRepositoryCheckoutIds.filter(checkoutId => checkoutId === options.targetCheckoutId);
-    const databases =
-      options.targetCheckoutId === undefined
-        ? allDatabases
-        : allDatabases.filter(database => path.basename(path.dirname(database)) === options.targetCheckoutId);
-    const obsoleteBefore =
-      options.targetCheckoutId === undefined
-        ? yield* inspectObsoleteCodeGraphStores(threadnoteHome)
-        : emptyObsoleteInventory();
-    const deep = options.mode !== 'quick';
-    let deferredDatabases = 0;
-    let databaseCount = databases.length;
-    let discarded = 0;
-    let migratedDatabases = 0;
-    let removedIncompleteSnapshots = 0;
-    let remainingIncompleteSnapshots = 0;
-    let removedTemporaryFiles = 0;
-    let readySnapshots = 0;
-    for (const [index, database] of databases.entries()) {
-      const progress = (input: Omit<CodeGraphMaintenanceProgress, 'current' | 'total'>) =>
-        onProgress?.({current: index + 1, total: databases.length, ...input}) ?? Effect.void;
-      yield* progress({phase: 'checking'});
-      const repositoryRoot = path.dirname(database);
-      const maintained = yield* withDatabaseLock(
-        fs,
-        path,
-        threadnoteHome,
-        database,
-        Effect.gen(function* () {
-          const decision = yield* Effect.scoped(
-            Effect.gen(function* () {
-              const checkoutId = path.basename(repositoryRoot);
-              const repositoryTarget = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-              if (repositoryTarget === undefined) {
-                return yield* CodeGraphMaintenanceError.make({
-                  message: 'Code graph checkout target changed before repair.',
-                });
-              }
-              return yield* store.withSession(
-                database,
-                Effect.gen(function* () {
-                  let diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
-                  let previewingSchemaMigration = false;
-                  let previewedMigrationPreservesIncompleteSnapshots = false;
-                  // A same-name alias index can belong to another table or carry
-                  // incompatible keys. The initializer must never bless that drift.
-                  // Quick repair preserves the derived store for an explicit deep
-                  // decision; deep repair can discard it identically in preview and
-                  // apply without claiming that schema migration succeeded.
-                  if (
-                    diagnosed._tag === 'Some' &&
-                    diagnosed.value.integrity === 'incompatible' &&
-                    (diagnosed.value.snapshotFileCitationBaseIndexes === 'incompatible' ||
-                      diagnosed.value.snapshotFileCitationSchema === 'incompatible' ||
-                      diagnosed.value.snapshotFileCitationSchema === 'column-only-with-authority' ||
-                      (diagnosed.value.snapshotFileCitationSchema === 'released-absent-with-authority' &&
-                        diagnosed.value.persistentExtensionSchemaRevision !==
-                          CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR.value))
-                  ) {
-                    return deep ? ('discard' as const) : ('schema-upgrade-on-use' as const);
-                  }
-                  const schemaMigrationPreservesIncompleteSnapshots =
-                    diagnosed._tag === 'Some' &&
-                    codeGraphSchemaMigrationPreservesIncompleteSnapshots(
-                      diagnosed.value.persistentExtensionSchemaRevision,
-                      diagnosed.value.snapshotFileCitationSchema,
-                      diagnosed.value.snapshotFileCitationBaseIndexes,
+  const repair = (reporter?: CodeGraphMaintenanceProgressReporter) =>
+    Effect.gen(function* () {
+      const allDatabases = yield* codeGraphDatabasePaths(threadnoteHome);
+      const allRepositoryCheckoutIds = yield* codeGraphRepositoryCheckoutIds(threadnoteHome);
+      const repositoryCheckoutIds =
+        options.targetCheckoutId === undefined
+          ? allRepositoryCheckoutIds
+          : allRepositoryCheckoutIds.filter(checkoutId => checkoutId === options.targetCheckoutId);
+      const databases =
+        options.targetCheckoutId === undefined
+          ? allDatabases
+          : allDatabases.filter(database => path.basename(path.dirname(database)) === options.targetCheckoutId);
+      const obsoleteBefore =
+        options.targetCheckoutId === undefined
+          ? yield* inspectObsoleteCodeGraphStores(threadnoteHome)
+          : emptyObsoleteInventory();
+      const deep = options.mode !== 'quick';
+      let deferredDatabases = 0;
+      let databaseCount = databases.length;
+      let discarded = 0;
+      let migratedDatabases = 0;
+      let removedIncompleteSnapshots = 0;
+      let remainingIncompleteSnapshots = 0;
+      let removedTemporaryFiles = 0;
+      let readySnapshots = 0;
+      const reportedTotal = Math.max(1, databases.length);
+      yield* reporter?.progress({completed: 0, phase: 'acquiring-gates', total: reportedTotal}) ?? Effect.void;
+      for (const [index, database] of databases.entries()) {
+        const progress = (input: Omit<CodeGraphMaintenanceProgress, 'current' | 'total'>) =>
+          (reporter?.progress(repairReportedProgress(index + 1, reportedTotal, input.phase)) ?? Effect.void).pipe(
+            Effect.andThen(onProgress?.({current: index + 1, total: databases.length, ...input}) ?? Effect.void),
+          );
+        yield* progress({phase: 'checking'});
+        const repositoryRoot = path.dirname(database);
+        const maintained = yield* withDatabaseLock(
+          fs,
+          path,
+          threadnoteHome,
+          database,
+          Effect.gen(function* () {
+            const decision = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const checkoutId = path.basename(repositoryRoot);
+                const repositoryTarget = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+                if (repositoryTarget === undefined) {
+                  return yield* CodeGraphMaintenanceError.make({
+                    message: 'Code graph checkout target changed before repair.',
+                  });
+                }
+                return yield* store.withSession(
+                  database,
+                  Effect.gen(function* () {
+                    let diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(
+                      Effect.option,
                     );
-                  if (
-                    diagnosed._tag === 'Some' &&
-                    diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
-                    (diagnosed.value.integrity === 'incompatible' || diagnosed.value.integrity === 'migration-pending')
-                  ) {
-                    if (options.migrateSchema) {
-                      yield* progress({phase: 'migrating-schema'});
-                      if (dryRun) {
-                        if (
-                          diagnosed.value.integrity === 'migration-pending' ||
-                          schemaMigrationPreservesIncompleteSnapshots
-                        ) {
-                          const preparation = yield* store.prepareWorktreeReconciliationIndexes(database, {
-                            preview: true,
-                          });
-                          if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
-                          previewedMigrationPreservesIncompleteSnapshots =
-                            codeGraphSchemaMigrationPreservesIncompleteSnapshots(
-                              diagnosed.value.persistentExtensionSchemaRevision,
-                              diagnosed.value.snapshotFileCitationSchema,
-                              diagnosed.value.snapshotFileCitationBaseIndexes,
-                            );
-                        }
-                        migratedDatabases += 1;
-                        previewingSchemaMigration = true;
-                      } else {
-                        if (
-                          diagnosed.value.integrity === 'migration-pending' ||
-                          schemaMigrationPreservesIncompleteSnapshots
-                        ) {
-                          let preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
-                          for (
-                            let step = 1;
-                            preparation.state === 'prepared' &&
-                            step < CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT;
-                            step += 1
-                          ) {
-                            preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
-                          }
-                          if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
-                        }
-                        yield* store.initialize(database);
-                        diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(
-                          Effect.option,
-                        );
-                        if (diagnosed._tag === 'Some' && diagnosed.value?.integrity === 'ok') {
-                          migratedDatabases += 1;
-                        } else {
-                          return 'schema-upgrade-on-use' as const;
-                        }
-                      }
-                    } else {
-                      // Same-version beta databases with a missing revision or an
-                      // incompatible extension-table contract are recoverable on the
-                      // next ordinary writer open.
-                      // Never discard their ready snapshots as if the canonical graph
-                      // rows were corrupt merely because this maintenance pass is
-                      // deliberately read-only while holding the checkout gate.
-                      return 'schema-upgrade-on-use' as const;
+                    let previewingSchemaMigration = false;
+                    let previewedMigrationPreservesIncompleteSnapshots = false;
+                    // A same-name alias index can belong to another table or carry
+                    // incompatible keys. The initializer must never bless that drift.
+                    // Quick repair preserves the derived store for an explicit deep
+                    // decision; deep repair can discard it identically in preview and
+                    // apply without claiming that schema migration succeeded.
+                    if (
+                      diagnosed._tag === 'Some' &&
+                      diagnosed.value.integrity === 'incompatible' &&
+                      (diagnosed.value.snapshotFileCitationBaseIndexes === 'incompatible' ||
+                        diagnosed.value.snapshotFileCitationSchema === 'incompatible' ||
+                        diagnosed.value.snapshotFileCitationSchema === 'column-only-with-authority' ||
+                        (diagnosed.value.snapshotFileCitationSchema === 'released-absent-with-authority' &&
+                          diagnosed.value.persistentExtensionSchemaRevision !==
+                            CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR.value))
+                    ) {
+                      return deep ? ('discard' as const) : ('schema-upgrade-on-use' as const);
                     }
-                  }
-                  // A failed diagnostic is not evidence of corruption. In particular,
-                  // transient I/O, permissions, or an unreadable schema must never turn
-                  // an explicit deep check into recursive deletion of the graph store.
-                  if (diagnosed._tag === 'None') {
-                    return deep ? ('unreadable-database' as const) : ('deep-check-required' as const);
-                  }
-                  if (!previewingSchemaMigration && diagnosed.value.integrity !== 'ok') {
-                    return deep ? ('discard' as const) : ('deep-check-required' as const);
-                  }
-                  const incomplete = diagnosed.value.buildingSnapshots + diagnosed.value.failedSnapshots;
-                  let retainedIncompleteSnapshotIds: readonly string[] = [];
-                  readySnapshots += diagnosed.value.readySnapshots;
-                  if (!deep && incomplete > 0) return 'deep-check-required' as const;
-                  if (!deep) return 'maintained' as const;
-                  if (
-                    incomplete > 0 &&
-                    (!previewingSchemaMigration || previewedMigrationPreservesIncompleteSnapshots)
-                  ) {
-                    yield* progress({phase: 'cleaning-snapshots', snapshots: incomplete});
-                    const repaired = yield* store.repair(database, dryRun, {
-                      allowSchemaMigrationPreview: previewedMigrationPreservesIncompleteSnapshots,
-                    });
-                    const removed = repaired?.removedSnapshots ?? 0;
-                    retainedIncompleteSnapshotIds = repaired?.retainedIncompleteSnapshotIds ?? [];
-                    removedIncompleteSnapshots += removed;
-                    remainingIncompleteSnapshots += Math.max(0, incomplete - removed);
-                  }
-                  // Build-time cache GC can delete parser facts belonging to another
-                  // linked worktree before that worktree activates its snapshot. This
-                  // path has drained every worktree lock for the checkout, so
-                  // it is safe to collect cache facts shared by its linked worktrees.
-                  if (!dryRun) {
-                    yield* store.pruneRetiredSnapshots(database);
-                    yield* store.pruneCachedFacts(database, BUILTIN_LANGUAGE_PACK_REGISTRY.cacheIdentities);
-                  }
-                  yield* progress({phase: 'cleaning-vectors'});
-                  yield* options.interlock?.beforeSpoolCleanupVerification?.(repositoryTarget.path) ?? Effect.void;
-                  removedTemporaryFiles += yield* cleanTemporaryMaterializationSpoolFiles(
-                    fs,
-                    path,
-                    threadnoteHome,
-                    checkoutId,
-                    repositoryTarget,
-                    new Set(retainedIncompleteSnapshotIds),
-                    dryRun,
-                    options.interlock,
-                  );
-                  removedTemporaryFiles += yield* cleanTemporaryVectorFiles(
-                    fs,
-                    path,
-                    threadnoteHome,
-                    checkoutId,
-                    repositoryTarget,
-                    path.join(repositoryRoot, 'vectors'),
-                    dryRun,
-                    options.interlock,
-                  );
-                  return 'maintained' as const;
-                }),
-                {writerGateHeld: true},
+                    const schemaMigrationPreservesIncompleteSnapshots =
+                      diagnosed._tag === 'Some' &&
+                      codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+                        diagnosed.value.persistentExtensionSchemaRevision,
+                        diagnosed.value.snapshotFileCitationSchema,
+                        diagnosed.value.snapshotFileCitationBaseIndexes,
+                      );
+                    if (
+                      diagnosed._tag === 'Some' &&
+                      diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
+                      (diagnosed.value.integrity === 'incompatible' ||
+                        diagnosed.value.integrity === 'migration-pending')
+                    ) {
+                      if (options.migrateSchema) {
+                        yield* progress({phase: 'migrating-schema'});
+                        if (dryRun) {
+                          if (
+                            diagnosed.value.integrity === 'migration-pending' ||
+                            schemaMigrationPreservesIncompleteSnapshots
+                          ) {
+                            const preparation = yield* store.prepareWorktreeReconciliationIndexes(database, {
+                              preview: true,
+                            });
+                            if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
+                            previewedMigrationPreservesIncompleteSnapshots =
+                              codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+                                diagnosed.value.persistentExtensionSchemaRevision,
+                                diagnosed.value.snapshotFileCitationSchema,
+                                diagnosed.value.snapshotFileCitationBaseIndexes,
+                              );
+                          }
+                          migratedDatabases += 1;
+                          previewingSchemaMigration = true;
+                        } else {
+                          if (
+                            diagnosed.value.integrity === 'migration-pending' ||
+                            schemaMigrationPreservesIncompleteSnapshots
+                          ) {
+                            let preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
+                            for (
+                              let step = 1;
+                              preparation.state === 'prepared' &&
+                              step < CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT;
+                              step += 1
+                            ) {
+                              preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
+                            }
+                            if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
+                          }
+                          yield* store.initialize(database);
+                          diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(
+                            Effect.option,
+                          );
+                          if (diagnosed._tag === 'Some' && diagnosed.value?.integrity === 'ok') {
+                            migratedDatabases += 1;
+                          } else {
+                            return 'schema-upgrade-on-use' as const;
+                          }
+                        }
+                      } else {
+                        // Same-version beta databases with a missing revision or an
+                        // incompatible extension-table contract are recoverable on the
+                        // next ordinary writer open.
+                        // Never discard their ready snapshots as if the canonical graph
+                        // rows were corrupt merely because this maintenance pass is
+                        // deliberately read-only while holding the checkout gate.
+                        return 'schema-upgrade-on-use' as const;
+                      }
+                    }
+                    // A failed diagnostic is not evidence of corruption. In particular,
+                    // transient I/O, permissions, or an unreadable schema must never turn
+                    // an explicit deep check into recursive deletion of the graph store.
+                    if (diagnosed._tag === 'None') {
+                      return deep ? ('unreadable-database' as const) : ('deep-check-required' as const);
+                    }
+                    if (!previewingSchemaMigration && diagnosed.value.integrity !== 'ok') {
+                      return deep ? ('discard' as const) : ('deep-check-required' as const);
+                    }
+                    const incomplete = diagnosed.value.buildingSnapshots + diagnosed.value.failedSnapshots;
+                    let retainedIncompleteSnapshotIds: readonly string[] = [];
+                    readySnapshots += diagnosed.value.readySnapshots;
+                    if (!deep && incomplete > 0) return 'deep-check-required' as const;
+                    if (!deep) return 'maintained' as const;
+                    if (
+                      incomplete > 0 &&
+                      (!previewingSchemaMigration || previewedMigrationPreservesIncompleteSnapshots)
+                    ) {
+                      yield* progress({phase: 'cleaning-snapshots', snapshots: incomplete});
+                      const repaired = yield* store.repair(database, dryRun, {
+                        allowSchemaMigrationPreview: previewedMigrationPreservesIncompleteSnapshots,
+                      });
+                      const removed = repaired?.removedSnapshots ?? 0;
+                      retainedIncompleteSnapshotIds = repaired?.retainedIncompleteSnapshotIds ?? [];
+                      removedIncompleteSnapshots += removed;
+                      remainingIncompleteSnapshots += Math.max(0, incomplete - removed);
+                    }
+                    // Build-time cache GC can delete parser facts belonging to another
+                    // linked worktree before that worktree activates its snapshot. This
+                    // path has drained every worktree lock for the checkout, so
+                    // it is safe to collect cache facts shared by its linked worktrees.
+                    if (!dryRun) {
+                      yield* store.pruneRetiredSnapshots(database);
+                      yield* store.pruneCachedFacts(database, BUILTIN_LANGUAGE_PACK_REGISTRY.cacheIdentities);
+                    }
+                    yield* progress({phase: 'cleaning-vectors'});
+                    yield* options.interlock?.beforeSpoolCleanupVerification?.(repositoryTarget.path) ?? Effect.void;
+                    removedTemporaryFiles += yield* cleanTemporaryMaterializationSpoolFiles(
+                      fs,
+                      path,
+                      threadnoteHome,
+                      checkoutId,
+                      repositoryTarget,
+                      new Set(retainedIncompleteSnapshotIds),
+                      dryRun,
+                      options.interlock,
+                    );
+                    removedTemporaryFiles += yield* cleanTemporaryVectorFiles(
+                      fs,
+                      path,
+                      threadnoteHome,
+                      checkoutId,
+                      repositoryTarget,
+                      path.join(repositoryRoot, 'vectors'),
+                      dryRun,
+                      options.interlock,
+                    );
+                    return 'maintained' as const;
+                  }),
+                  {writerGateHeld: true},
+                );
+              }),
+            );
+            if (decision !== 'discard') return decision;
+
+            // The session-scoped SqliteClient has finalized before this branch.
+            // Keep the repository and database writer gates held while closing
+            // the handle first, otherwise Windows rejects recursive deletion of
+            // the incompatible SQLite store with a sharing violation.
+            discarded += 1;
+            yield* progress({phase: 'discarding'});
+            if (!dryRun) yield* fs.remove(repositoryRoot, {force: true, recursive: true});
+            return 'maintained' as const;
+          }),
+          0,
+          options.interlock?.afterWorktreeDrain,
+        ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed('active-build' as const)));
+        if (maintained !== 'maintained') {
+          deferredDatabases += 1;
+          yield* progress({
+            phase: 'deferred',
+            reason: maintained,
+          });
+        }
+      }
+      const databaseCheckoutIds = new Set(databases.map(database => path.basename(path.dirname(database))));
+      const spoolOnlyCheckoutIds = deep
+        ? repositoryCheckoutIds.filter(checkoutId => !databaseCheckoutIds.has(checkoutId))
+        : [];
+      for (const checkoutId of spoolOnlyCheckoutIds) {
+        const repositoryRoot = codeGraphRepositoryRoot(path, threadnoteHome, checkoutId);
+        const database = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+        const cleaned = yield* withDatabaseLock(
+          fs,
+          path,
+          threadnoteHome,
+          database,
+          Effect.scoped(
+            Effect.gen(function* () {
+              // The root was database-less during inventory, but a builder may
+              // have completed before this checkout's gates were acquired. Do
+              // not apply the empty-retention model to its newly durable state.
+              if (yield* fs.exists(database)) return undefined;
+              const repositoryTarget = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+              if (repositoryTarget === undefined) return 0;
+              yield* options.interlock?.beforeSpoolCleanupVerification?.(repositoryTarget.path) ?? Effect.void;
+              return yield* cleanTemporaryMaterializationSpoolFiles(
+                fs,
+                path,
+                threadnoteHome,
+                checkoutId,
+                repositoryTarget,
+                new Set(),
+                dryRun,
+                options.interlock,
               );
             }),
-          );
-          if (decision !== 'discard') return decision;
-
-          // The session-scoped SqliteClient has finalized before this branch.
-          // Keep the repository and database writer gates held while closing
-          // the handle first, otherwise Windows rejects recursive deletion of
-          // the incompatible SQLite store with a sharing violation.
-          discarded += 1;
-          yield* progress({phase: 'discarding'});
-          if (!dryRun) yield* fs.remove(repositoryRoot, {force: true, recursive: true});
-          return 'maintained' as const;
-        }),
-        0,
-        options.interlock?.afterWorktreeDrain,
-      ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed('active-build' as const)));
-      if (maintained !== 'maintained') {
-        deferredDatabases += 1;
-        yield* progress({
-          phase: 'deferred',
-          reason: maintained,
-        });
+          ),
+          0,
+          options.interlock?.afterWorktreeDrain,
+        ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed(0)));
+        if (cleaned === undefined) {
+          databaseCount += 1;
+          deferredDatabases += 1;
+        } else {
+          removedTemporaryFiles += cleaned;
+        }
       }
-    }
-    const databaseCheckoutIds = new Set(databases.map(database => path.basename(path.dirname(database))));
-    const spoolOnlyCheckoutIds = deep
-      ? repositoryCheckoutIds.filter(checkoutId => !databaseCheckoutIds.has(checkoutId))
-      : [];
-    for (const checkoutId of spoolOnlyCheckoutIds) {
-      const repositoryRoot = codeGraphRepositoryRoot(path, threadnoteHome, checkoutId);
-      const database = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
-      const cleaned = yield* withDatabaseLock(
-        fs,
-        path,
-        threadnoteHome,
-        database,
-        Effect.scoped(
-          Effect.gen(function* () {
-            // The root was database-less during inventory, but a builder may
-            // have completed before this checkout's gates were acquired. Do
-            // not apply the empty-retention model to its newly durable state.
-            if (yield* fs.exists(database)) return undefined;
-            const repositoryTarget = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-            if (repositoryTarget === undefined) return 0;
-            yield* options.interlock?.beforeSpoolCleanupVerification?.(repositoryTarget.path) ?? Effect.void;
-            return yield* cleanTemporaryMaterializationSpoolFiles(
-              fs,
-              path,
-              threadnoteHome,
-              checkoutId,
-              repositoryTarget,
-              new Set(),
-              dryRun,
-              options.interlock,
+      const currentDatabases =
+        options.targetCheckoutId === undefined
+          ? yield* codeGraphDatabasePaths(threadnoteHome)
+          : (yield* codeGraphDatabasePaths(threadnoteHome)).filter(
+              database => path.basename(path.dirname(database)) === options.targetCheckoutId,
             );
-          }),
-        ),
-        0,
-        options.interlock?.afterWorktreeDrain,
-      ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed(0)));
-      if (cleaned === undefined) {
-        databaseCount += 1;
-        deferredDatabases += 1;
-      } else {
-        removedTemporaryFiles += cleaned;
-      }
-    }
-    const currentDatabases =
-      options.targetCheckoutId === undefined
-        ? yield* codeGraphDatabasePaths(threadnoteHome)
-        : (yield* codeGraphDatabasePaths(threadnoteHome)).filter(
-            database => path.basename(path.dirname(database)) === options.targetCheckoutId,
-          );
-    const obsolete =
-      options.targetCheckoutId !== undefined
-        ? emptyObsoleteInventory()
-        : dryRun
-          ? obsoleteBefore
-          : yield* inspectObsoleteCodeGraphStores(threadnoteHome);
-    const summary = {
-      databases: databaseCount,
-      deferredDatabases,
-      discarded,
-      migratedDatabases,
-      obsoleteStoreBytes: obsolete.bytes,
-      obsoleteStoreCheckouts: obsolete.checkouts.length,
-      obsoleteStoreFiles: obsolete.fileCount,
-      removedIncompleteSnapshots,
-      removedTemporaryFiles,
-      unsafeObsoleteEntries: obsolete.unsafeEntryCount,
-    } satisfies CodeGraphRepairSummary;
-    yield* onComplete?.({
-      doctorCheck: codeGraphDoctorResult(
-        currentDatabases.length,
-        readySnapshots,
-        dryRun ? removedIncompleteSnapshots + remainingIncompleteSnapshots : remainingIncompleteSnapshots,
-        dryRun ? discarded : 0,
+      const obsolete =
+        options.targetCheckoutId !== undefined
+          ? emptyObsoleteInventory()
+          : dryRun
+            ? obsoleteBefore
+            : yield* inspectObsoleteCodeGraphStores(threadnoteHome);
+      const summary = {
+        databases: databaseCount,
         deferredDatabases,
-        dryRun ? migratedDatabases : 0,
-        obsolete,
-      ),
-      summary,
-    }) ?? Effect.void;
-    return summary;
-  });
+        discarded,
+        migratedDatabases,
+        obsoleteStoreBytes: obsolete.bytes,
+        obsoleteStoreCheckouts: obsolete.checkouts.length,
+        obsoleteStoreFiles: obsolete.fileCount,
+        removedIncompleteSnapshots,
+        removedTemporaryFiles,
+        unsafeObsoleteEntries: obsolete.unsafeEntryCount,
+      } satisfies CodeGraphRepairSummary;
+      yield* onComplete?.({
+        doctorCheck: codeGraphDoctorResult(
+          currentDatabases.length,
+          readySnapshots,
+          dryRun ? removedIncompleteSnapshots + remainingIncompleteSnapshots : remainingIncompleteSnapshots,
+          dryRun ? discarded : 0,
+          deferredDatabases,
+          dryRun ? migratedDatabases : 0,
+          obsolete,
+        ),
+        summary,
+      }) ?? Effect.void;
+      return summary;
+    });
   if (options.targetCheckoutId !== undefined) {
     // The checkout gate plus the under-writer-gate builder recheck isolates this
     // repository without pausing builders for unrelated checkouts.
-    return yield* repair;
+    return yield* repair();
   }
   return yield* withExclusiveFileLock(
     fs,
     codeGraphMaintenanceLockPath(path, threadnoteHome),
     CODE_GRAPH_LOCK_OPTIONS,
-    withCodeGraphMaintenanceIntent(threadnoteHome, repair),
+    withCodeGraphReportedMaintenanceIntent(
+      threadnoteHome,
+      {operation: 'graph-maintenance'},
+      {completed: 0, phase: 'acquiring-gates', total: 1},
+      reporter => repair(reporter),
+    ),
   );
 });
 
@@ -690,6 +707,51 @@ function codeGraphRepositoryCheckoutIds(threadnoteHome: string) {
   });
 }
 
+function repairReportedProgress(
+  current: number,
+  total: number,
+  phase: CodeGraphMaintenanceProgress['phase'],
+): CodeGraphReportedMaintenanceProgress {
+  const safeTotal = Math.max(1, total);
+  return {
+    completed: Math.min(safeTotal, Math.max(0, current)),
+    phase:
+      phase === 'cleaning-snapshots' || phase === 'cleaning-vectors' || phase === 'discarding'
+        ? 'retiring-and-cleaning'
+        : 'verifying-graph',
+    total: safeTotal,
+  };
+}
+
+function publishPurgeProgress(
+  reporter: CodeGraphMaintenanceProgressReporter,
+  onProgress: CodeGraphPurgeProgressHandler | undefined,
+  dryRun: boolean,
+  input: {
+    readonly checkoutCurrent?: number;
+    readonly checkoutTotal?: number;
+    readonly completed: number;
+    readonly filesRemoved?: number;
+    readonly filesTotal?: number;
+    readonly gate: CodeGraphReportedMaintenanceProgress['phase'];
+    readonly phase: CodeGraphCliPurgeProgress['phase'];
+    readonly total: number;
+  },
+) {
+  return reporter.progress({completed: input.completed, phase: input.gate, total: input.total}).pipe(
+    Effect.andThen(
+      onProgress?.({
+        ...(input.checkoutCurrent === undefined ? {} : {checkoutCurrent: input.checkoutCurrent}),
+        ...(input.checkoutTotal === undefined ? {} : {checkoutTotal: input.checkoutTotal}),
+        dryRun,
+        ...(input.filesRemoved === undefined ? {} : {filesRemoved: input.filesRemoved}),
+        ...(input.filesTotal === undefined ? {} : {filesTotal: input.filesTotal}),
+        phase: input.phase,
+      }) ?? Effect.void,
+    ),
+  );
+}
+
 /**
  * Explicitly removes only older schema-version SQLite artifacts from one checkout.
  * Both maintenance and checkout locks are attempted once; an active build or repair
@@ -701,6 +763,7 @@ export const purgeObsoleteCodeGraphStores = Effect.fn('codeGraph.purgeObsoleteSt
   options: {
     readonly dryRun: boolean;
     readonly interlock?: ObsoleteCodeGraphStorePurgeInterlock;
+    readonly onProgress?: CodeGraphPurgeProgressHandler;
   },
 ) {
   const fs = yield* FileSystem.FileSystem;
@@ -712,43 +775,84 @@ export const purgeObsoleteCodeGraphStores = Effect.fn('codeGraph.purgeObsoleteSt
     fs,
     codeGraphMaintenanceLockPath(path, threadnoteHome),
     CODE_GRAPH_PURGE_LOCK_OPTIONS,
-    withCodeGraphMaintenanceIntent(
+    withCodeGraphReportedMaintenanceIntent(
       threadnoteHome,
-      withExclusiveFileLock(
-        fs,
-        codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
-        CODE_GRAPH_PURGE_LOCK_OPTIONS,
-        Effect.gen(function* () {
-          yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, checkoutId, 0);
-          return yield* withCodeGraphDatabaseWriteLock(
-            threadnoteHome,
-            checkoutId,
-            Effect.gen(function* () {
-              const initial = yield* inspectObsoleteCodeGraphStores(threadnoteHome, checkoutId);
-              yield* refuseUnsafeObsoleteInventory(initial);
-              yield* options.interlock?.beforeVerification?.(initial) ?? Effect.void;
-              const verified = yield* inspectObsoleteCodeGraphStores(threadnoteHome, checkoutId);
-              yield* refuseUnsafeObsoleteInventory(verified);
-              const checkout = verified.checkouts.find(entry => entry.checkoutId === checkoutId);
-              const files = checkout?.files ?? [];
-              if (!options.dryRun) {
-                for (const file of files) {
-                  yield* verifyObsoletePurgeTarget(fs, path, threadnoteHome, checkoutId, file);
+      {checkoutId, operation: 'graph-maintenance'},
+      {completed: 0, phase: 'acquiring-gates', total: 4},
+      reporter =>
+        withExclusiveFileLock(
+          fs,
+          codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
+          CODE_GRAPH_PURGE_LOCK_OPTIONS,
+          Effect.gen(function* () {
+            yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+              completed: 1,
+              gate: 'waiting-builders',
+              phase: 'waiting-builders',
+              total: 4,
+            });
+            yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, checkoutId, 0);
+            return yield* withCodeGraphDatabaseWriteLock(
+              threadnoteHome,
+              checkoutId,
+              Effect.gen(function* () {
+                yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                  completed: 2,
+                  gate: 'verifying-graph',
+                  phase: 'verifying',
+                  total: 4,
+                });
+                const initial = yield* inspectObsoleteCodeGraphStores(threadnoteHome, checkoutId);
+                yield* refuseUnsafeObsoleteInventory(initial);
+                yield* options.interlock?.beforeVerification?.(initial) ?? Effect.void;
+                const verified = yield* inspectObsoleteCodeGraphStores(threadnoteHome, checkoutId);
+                yield* refuseUnsafeObsoleteInventory(verified);
+                const checkout = verified.checkouts.find(entry => entry.checkoutId === checkoutId);
+                const files = checkout?.files ?? [];
+                yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                  completed: 3,
+                  filesRemoved: 0,
+                  filesTotal: files.length,
+                  gate: 'retiring-and-cleaning',
+                  phase: 'removing-obsolete',
+                  total: 4,
+                });
+                if (!options.dryRun) {
+                  for (const file of files) {
+                    yield* verifyObsoletePurgeTarget(fs, path, threadnoteHome, checkoutId, file);
+                  }
+                  for (const [index, file] of files.entries()) {
+                    yield* fs.remove(file.path);
+                    yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                      completed: 4,
+                      filesRemoved: index + 1,
+                      filesTotal: files.length,
+                      gate: 'retiring-and-cleaning',
+                      phase: 'deleting',
+                      total: 4,
+                    });
+                  }
                 }
-                for (const file of files) yield* fs.remove(file.path);
-              }
-              return {
-                bytes: checkout?.bytes ?? 0,
-                checkoutId,
-                dryRun: options.dryRun,
-                fileCount: files.length,
-                versions: checkout?.versions ?? [],
-              } satisfies ObsoleteCodeGraphStorePurgeSummary;
-            }),
-            0,
-          );
-        }),
-      ),
+                yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                  completed: 4,
+                  filesRemoved: files.length,
+                  filesTotal: files.length,
+                  gate: 'retiring-and-cleaning',
+                  phase: 'deleting',
+                  total: 4,
+                });
+                return {
+                  bytes: checkout?.bytes ?? 0,
+                  checkoutId,
+                  dryRun: options.dryRun,
+                  fileCount: files.length,
+                  versions: checkout?.versions ?? [],
+                } satisfies ObsoleteCodeGraphStorePurgeSummary;
+              }),
+              0,
+            );
+          }),
+        ),
     ),
   );
 });
@@ -765,6 +869,7 @@ export const purgeCodeGraphIndex = Effect.fn('codeGraph.purgeIndex')(function* (
   options: {
     readonly dryRun: boolean;
     readonly interlock?: CodeGraphIndexPurgeInterlock;
+    readonly onProgress?: CodeGraphPurgeProgressHandler;
     readonly waitTimeoutMilliseconds?: number;
   },
 ) {
@@ -780,70 +885,163 @@ export const purgeCodeGraphIndex = Effect.fn('codeGraph.purgeIndex')(function* (
     fs,
     codeGraphMaintenanceLockPath(path, threadnoteHome),
     lockOptions,
-    withCodeGraphMaintenanceIntent(
+    withCodeGraphReportedMaintenanceIntent(
       threadnoteHome,
-      withExclusiveFileLock(
-        fs,
-        codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
-        lockOptions,
-        Effect.gen(function* () {
-          yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, checkoutId, waitTimeoutMilliseconds);
-          return yield* withCodeGraphDatabaseWriteLock(
-            threadnoteHome,
-            checkoutId,
-            Effect.gen(function* () {
-              const purgeTarget = yield* Effect.scoped(
-                Effect.gen(function* () {
-                  // Keep the original directory open until it has been moved into quarantine.
-                  // POSIX may recycle a deleted directory's inode immediately; the live handle
-                  // prevents that replacement from comparing equal to the planned target.
-                  const initial = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-                  yield* options.interlock?.beforeVerification?.() ?? Effect.void;
-                  const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-                  if (!sameCodeGraphIndexPurgeTarget(initial, verified)) {
-                    return yield* CodeGraphMaintenanceError.make({
-                      message: 'Code graph checkout target changed before purge.',
+      {checkoutId, operation: 'graph-maintenance'},
+      {completed: 0, phase: 'acquiring-gates', total: 5},
+      reporter =>
+        withExclusiveFileLock(
+          fs,
+          codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
+          lockOptions,
+          Effect.gen(function* () {
+            yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+              completed: 1,
+              gate: 'waiting-builders',
+              phase: 'waiting-builders',
+              total: 5,
+            });
+            yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, checkoutId, waitTimeoutMilliseconds);
+            return yield* withCodeGraphDatabaseWriteLock(
+              threadnoteHome,
+              checkoutId,
+              Effect.gen(function* () {
+                const purgeTarget = yield* Effect.scoped(
+                  Effect.gen(function* () {
+                    // Keep the original directory open until it has been moved into quarantine.
+                    // POSIX may recycle a deleted directory's inode immediately; the live handle
+                    // prevents that replacement from comparing equal to the planned target.
+                    yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                      completed: 2,
+                      gate: 'verifying-graph',
+                      phase: 'verifying',
+                      total: 5,
                     });
-                  }
-                  if (verified === undefined || options.dryRun) {
-                    return {existed: verified !== undefined, quarantine: undefined};
-                  }
+                    const initial = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+                    yield* options.interlock?.beforeVerification?.() ?? Effect.void;
+                    const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+                    if (!sameCodeGraphIndexPurgeTarget(initial, verified)) {
+                      return yield* CodeGraphMaintenanceError.make({
+                        message: 'Code graph checkout target changed before purge.',
+                      });
+                    }
+                    if (verified === undefined || options.dryRun) {
+                      return {existed: verified !== undefined, quarantine: undefined};
+                    }
 
-                  yield* options.interlock?.beforeRemoval?.() ?? Effect.void;
-                  const quarantine = path.join(
-                    path.dirname(verified.path),
-                    `.${checkoutId}.${yield* crypto.randomUUIDv4}.purging`,
-                  );
-                  yield* fs.rename(verified.path, quarantine);
-                  const moved = yield* inspectQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine);
-                  if (!sameCodeGraphIndexPurgeTarget(verified, moved)) {
-                    yield* restoreQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine, verified.path);
-                    return yield* CodeGraphMaintenanceError.make({
-                      message: 'Code graph checkout target changed before purge.',
+                    yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                      completed: 3,
+                      gate: 'retiring-and-cleaning',
+                      phase: 'quarantining',
+                      total: 5,
                     });
-                  }
-                  return {existed: true, quarantine};
-                }),
-              );
-              if (purgeTarget.quarantine !== undefined) {
-                // Close the directory handle before recursive deletion for Windows parity.
-                yield* fs.remove(purgeTarget.quarantine, {force: true, recursive: true});
-              }
-              return {
-                checkoutId,
-                dryRun: options.dryRun,
-                existed: purgeTarget.existed,
-              } satisfies CodeGraphIndexPurgeSummary;
-            }),
-            waitTimeoutMilliseconds,
-          );
-        }),
-      ),
+                    yield* options.interlock?.beforeRemoval?.() ?? Effect.void;
+                    const quarantine = path.join(
+                      path.dirname(verified.path),
+                      `.${checkoutId}.${yield* crypto.randomUUIDv4}.purging`,
+                    );
+                    yield* fs.rename(verified.path, quarantine);
+                    const moved = yield* inspectQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine);
+                    if (!sameCodeGraphIndexPurgeTarget(verified, moved)) {
+                      yield* restoreQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine, verified.path);
+                      return yield* CodeGraphMaintenanceError.make({
+                        message: 'Code graph checkout target changed before purge.',
+                      });
+                    }
+                    return {existed: true, quarantine};
+                  }),
+                );
+                if (purgeTarget.quarantine !== undefined) {
+                  yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                    completed: 4,
+                    gate: 'retiring-and-cleaning',
+                    phase: 'deleting',
+                    total: 5,
+                  });
+                  // Close the directory handle before recursive deletion for Windows parity.
+                  yield* fs.remove(purgeTarget.quarantine, {force: true, recursive: true});
+                }
+                yield* publishPurgeProgress(reporter, options.onProgress, options.dryRun, {
+                  completed: 5,
+                  gate: 'retiring-and-cleaning',
+                  phase: 'deleting',
+                  total: 5,
+                });
+                return {
+                  checkoutId,
+                  dryRun: options.dryRun,
+                  existed: purgeTarget.existed,
+                } satisfies CodeGraphIndexPurgeSummary;
+              }),
+              waitTimeoutMilliseconds,
+            );
+          }),
+        ),
     ),
   );
 });
 
-export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(function* (threadnoteHome: string) {
+export const purgeCodeGraphRepositoryRoot = Effect.fn('codeGraph.purgeRepositoryRoot')(function* (
+  threadnoteHome: string,
+  checkoutId: string,
+  repositoryRoot: string,
+  onProgress?: CodeGraphPurgeProgressHandler,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* withExclusiveFileLock(
+    fs,
+    codeGraphMaintenanceLockPath(path, threadnoteHome),
+    CODE_GRAPH_LOCK_OPTIONS,
+    withCodeGraphReportedMaintenanceIntent(
+      threadnoteHome,
+      {checkoutId, operation: 'graph-maintenance'},
+      {completed: 0, phase: 'acquiring-gates', total: 3},
+      reporter =>
+        withExclusiveFileLock(
+          fs,
+          codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
+          CODE_GRAPH_LOCK_OPTIONS,
+          Effect.gen(function* () {
+            yield* publishPurgeProgress(reporter, onProgress, false, {
+              completed: 1,
+              gate: 'waiting-builders',
+              phase: 'waiting-builders',
+              total: 3,
+            });
+            yield* awaitCodeGraphWorktreeBuilds(
+              threadnoteHome,
+              checkoutId,
+              CODE_GRAPH_LOCK_OPTIONS.waitTimeoutMilliseconds,
+            );
+            yield* publishPurgeProgress(reporter, onProgress, false, {
+              completed: 2,
+              gate: 'retiring-and-cleaning',
+              phase: 'deleting',
+              total: 3,
+            });
+            yield* withCodeGraphDatabaseWriteLock(
+              threadnoteHome,
+              checkoutId,
+              fs.remove(repositoryRoot, {recursive: true, force: true}),
+            );
+            yield* publishPurgeProgress(reporter, onProgress, false, {
+              completed: 3,
+              gate: 'retiring-and-cleaning',
+              phase: 'deleting',
+              total: 3,
+            });
+          }),
+        ),
+    ),
+  );
+  return repositoryRoot;
+});
+
+export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(function* (
+  threadnoteHome: string,
+  onProgress?: CodeGraphPurgeProgressHandler,
+) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const repositories = codeGraphRepositoriesRoot(path, threadnoteHome);
@@ -851,43 +1049,74 @@ export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(f
     fs,
     codeGraphMaintenanceLockPath(path, threadnoteHome),
     CODE_GRAPH_LOCK_OPTIONS,
-    withCodeGraphMaintenanceIntent(
+    withCodeGraphReportedMaintenanceIntent(
       threadnoteHome,
-      Effect.gen(function* () {
-        if (!(yield* fs.exists(repositories))) return path.dirname(repositories);
-        if ((yield* fs.readLink(repositories).pipe(Effect.option))._tag === 'Some') {
-          yield* fs.remove(repositories, {force: true});
-          return path.dirname(repositories);
-        }
-        const repositoryIds = (yield* fs.readDirectory(repositories))
-          .filter(name => /^[0-9a-f]{64}$/.test(name))
-          .sort();
-        for (const repositoryId of repositoryIds) {
-          const repositoryRoot = path.join(repositories, repositoryId);
-          if ((yield* fs.readLink(repositoryRoot).pipe(Effect.option))._tag === 'Some') continue;
-          yield* withExclusiveFileLock(
-            fs,
-            codeGraphRepositoryLockPath(path, threadnoteHome, repositoryId),
-            CODE_GRAPH_LOCK_OPTIONS,
-            awaitCodeGraphWorktreeBuilds(
-              threadnoteHome,
-              repositoryId,
-              CODE_GRAPH_LOCK_OPTIONS.waitTimeoutMilliseconds,
-            ).pipe(
-              Effect.andThen(
-                withCodeGraphDatabaseWriteLock(
-                  threadnoteHome,
-                  repositoryId,
-                  fs.remove(repositoryRoot, {force: true, recursive: true}),
+      {operation: 'graph-maintenance'},
+      {completed: 0, phase: 'acquiring-gates', total: 1},
+      reporter =>
+        Effect.gen(function* () {
+          if (!(yield* fs.exists(repositories))) return path.dirname(repositories);
+          if ((yield* fs.readLink(repositories).pipe(Effect.option))._tag === 'Some') {
+            yield* fs.remove(repositories, {force: true});
+            return path.dirname(repositories);
+          }
+          const repositoryIds = (yield* fs.readDirectory(repositories))
+            .filter(name => /^[0-9a-f]{64}$/.test(name))
+            .sort();
+          const total = Math.max(1, repositoryIds.length);
+          yield* reporter.progress({completed: 0, phase: 'waiting-builders', total});
+          for (const [index, repositoryId] of repositoryIds.entries()) {
+            const repositoryRoot = path.join(repositories, repositoryId);
+            if ((yield* fs.readLink(repositoryRoot).pipe(Effect.option))._tag === 'Some') continue;
+            yield* publishPurgeProgress(reporter, onProgress, false, {
+              checkoutCurrent: index + 1,
+              checkoutTotal: repositoryIds.length,
+              completed: index,
+              gate: 'waiting-builders',
+              phase: 'waiting-builders',
+              total,
+            });
+            yield* withExclusiveFileLock(
+              fs,
+              codeGraphRepositoryLockPath(path, threadnoteHome, repositoryId),
+              CODE_GRAPH_LOCK_OPTIONS,
+              awaitCodeGraphWorktreeBuilds(
+                threadnoteHome,
+                repositoryId,
+                CODE_GRAPH_LOCK_OPTIONS.waitTimeoutMilliseconds,
+              ).pipe(
+                Effect.andThen(
+                  Effect.gen(function* () {
+                    yield* publishPurgeProgress(reporter, onProgress, false, {
+                      checkoutCurrent: index + 1,
+                      checkoutTotal: repositoryIds.length,
+                      completed: index,
+                      gate: 'retiring-and-cleaning',
+                      phase: 'deleting',
+                      total,
+                    });
+                    yield* withCodeGraphDatabaseWriteLock(
+                      threadnoteHome,
+                      repositoryId,
+                      fs.remove(repositoryRoot, {force: true, recursive: true}),
+                    );
+                  }),
                 ),
               ),
-            ),
-          );
-        }
-        const graphRoot = path.dirname(repositories);
-        yield* fs.remove(graphRoot, {force: true, recursive: true});
-        return graphRoot;
-      }),
+            );
+          }
+          const graphRoot = path.dirname(repositories);
+          yield* publishPurgeProgress(reporter, onProgress, false, {
+            checkoutCurrent: repositoryIds.length,
+            checkoutTotal: repositoryIds.length,
+            completed: total,
+            gate: 'retiring-and-cleaning',
+            phase: 'deleting',
+            total,
+          });
+          yield* fs.remove(graphRoot, {force: true, recursive: true});
+          return graphRoot;
+        }),
     ),
   );
 });

--- a/src/code_graph/maintenance_coordinator.ts
+++ b/src/code_graph/maintenance_coordinator.ts
@@ -42,8 +42,8 @@ import {codeGraphAnonymousTelemetryComponent, emitCodeGraphBackgroundFailure} fr
 import {anonymousTelemetryDiagnosticFromError} from '../telemetry/diagnostic.js';
 
 export const CODE_GRAPH_MAINTENANCE_PENDING_DATABASE_LIMIT = 128;
-export const CODE_GRAPH_MAINTENANCE_AUTOMATIC_TAIL_MILLISECONDS = 250;
-export const CODE_GRAPH_MAINTENANCE_AUTOMATIC_TAIL_UNITS = 8;
+export const CODE_GRAPH_MAINTENANCE_AUTOMATIC_TAIL_MILLISECONDS = 2_000;
+export const CODE_GRAPH_MAINTENANCE_AUTOMATIC_TAIL_UNITS = 16;
 export const CODE_GRAPH_MAINTENANCE_LANES = ['residual', 'reconciliation', 'ordinary'] as const;
 
 export type CodeGraphMaintenanceLane = (typeof CODE_GRAPH_MAINTENANCE_LANES)[number];

--- a/src/code_graph/maintenance_gate.ts
+++ b/src/code_graph/maintenance_gate.ts
@@ -62,11 +62,16 @@ export interface CodeGraphMaintenanceProgressReporter {
   readonly progress: (progress: CodeGraphMaintenanceProgress) => Effect.Effect<void>;
 }
 
-export interface CodeGraphReportedMaintenanceTarget {
-  readonly checkoutId: string;
-  readonly operation: 'selected-snapshot-purge';
-  readonly snapshotId: string;
-}
+export type CodeGraphReportedMaintenanceTarget =
+  | {
+      readonly checkoutId: string;
+      readonly operation: 'selected-snapshot-purge';
+      readonly snapshotId: string;
+    }
+  | {
+      readonly checkoutId?: string;
+      readonly operation: 'graph-maintenance';
+    };
 
 interface StoredCodeGraphMaintenanceStatus extends CodeGraphMaintenanceStatus {
   readonly ownerDigest: string;
@@ -374,17 +379,7 @@ const validateReportedMaintenance = Effect.fn('codeGraph.validateReportedMainten
   target: CodeGraphReportedMaintenanceTarget,
   progress: CodeGraphMaintenanceProgress,
 ) {
-  if (
-    !/^[0-9a-f]{64}$/u.test(target.checkoutId) ||
-    !/^cgsn_[0-9a-f]{40}(?:-direct|-full-[0-9a-f]{16})?$/u.test(target.snapshotId) ||
-    target.operation !== 'selected-snapshot-purge' ||
-    !CODE_GRAPH_MAINTENANCE_PROGRESS_PHASES.includes(progress.phase) ||
-    !Number.isSafeInteger(progress.completed) ||
-    !Number.isSafeInteger(progress.total) ||
-    progress.completed < 0 ||
-    progress.total <= 0 ||
-    progress.completed > progress.total
-  ) {
+  if (!reportedMaintenanceTargetValid(target) || !reportedMaintenanceProgressValid(progress)) {
     return yield* CodeGraphMaintenanceGateError.make({message: 'Code graph maintenance progress is invalid.'});
   }
 });
@@ -403,13 +398,13 @@ const writeMaintenanceStatus = Effect.fn('codeGraph.writeMaintenanceStatus')(fun
   const ownerDigest = sha256HexSync(ownerToken);
   const now = DateTime.formatIso(yield* DateTime.now);
   const status = {
-    checkoutId: target.checkoutId,
+    ...(target.checkoutId === undefined ? {} : {checkoutId: target.checkoutId}),
     completed: progress.completed,
     operation: target.operation,
     ownerDigest,
     phase: progress.phase,
     schemaVersion: 1,
-    snapshotId: target.snapshotId,
+    ...(target.operation === 'selected-snapshot-purge' ? {snapshotId: target.snapshotId} : {}),
     startedAt: owner.startedAt ?? now,
     total: progress.total,
     updatedAt: now,
@@ -468,11 +463,6 @@ function parseMaintenanceStatus(value: string, expectedOwnerDigest: string): Cod
     if (
       schemaVersion !== 1 ||
       ownerDigest !== expectedOwnerDigest ||
-      operation !== 'selected-snapshot-purge' ||
-      typeof checkoutId !== 'string' ||
-      !/^[0-9a-f]{64}$/u.test(checkoutId) ||
-      typeof snapshotId !== 'string' ||
-      !/^cgsn_[0-9a-f]{40}(?:-direct|-full-[0-9a-f]{16})?$/u.test(snapshotId) ||
       !isCodeGraphMaintenanceProgressPhase(phase) ||
       !isSafeInteger(completed) ||
       !isSafeInteger(total) ||
@@ -484,12 +474,35 @@ function parseMaintenanceStatus(value: string, expectedOwnerDigest: string): Cod
     ) {
       return undefined;
     }
+    if (operation === 'selected-snapshot-purge') {
+      if (
+        typeof checkoutId !== 'string' ||
+        !/^[0-9a-f]{64}$/u.test(checkoutId) ||
+        typeof snapshotId !== 'string' ||
+        !/^cgsn_[0-9a-f]{40}(?:-direct|-full-[0-9a-f]{16})?$/u.test(snapshotId)
+      ) {
+        return undefined;
+      }
+      return {
+        checkoutId,
+        completed,
+        operation,
+        phase,
+        snapshotId,
+        startedAt,
+        total,
+        updatedAt,
+      };
+    }
+    if (operation !== 'graph-maintenance' || snapshotId !== undefined) return undefined;
+    if (checkoutId !== undefined && (typeof checkoutId !== 'string' || !/^[0-9a-f]{64}$/u.test(checkoutId))) {
+      return undefined;
+    }
     return {
-      checkoutId,
+      ...(typeof checkoutId === 'string' ? {checkoutId} : {}),
       completed,
       operation,
       phase,
-      snapshotId,
       startedAt,
       total,
       updatedAt,
@@ -562,6 +575,30 @@ export const CODE_GRAPH_GATE_LOCK_OPTIONS = {
   staleAfterMilliseconds: 120_000,
   waitTimeoutMilliseconds: 10 * 60_000,
 } as const;
+
+function reportedMaintenanceTargetValid(target: CodeGraphReportedMaintenanceTarget): boolean {
+  if (target.operation === 'selected-snapshot-purge') {
+    return (
+      /^[0-9a-f]{64}$/u.test(target.checkoutId) &&
+      /^cgsn_[0-9a-f]{40}(?:-direct|-full-[0-9a-f]{16})?$/u.test(target.snapshotId)
+    );
+  }
+  return (
+    target.operation === 'graph-maintenance' &&
+    (target.checkoutId === undefined || /^[0-9a-f]{64}$/u.test(target.checkoutId))
+  );
+}
+
+function reportedMaintenanceProgressValid(progress: CodeGraphMaintenanceProgress): boolean {
+  return (
+    CODE_GRAPH_MAINTENANCE_PROGRESS_PHASES.includes(progress.phase) &&
+    Number.isSafeInteger(progress.completed) &&
+    Number.isSafeInteger(progress.total) &&
+    progress.completed >= 0 &&
+    progress.total > 0 &&
+    progress.completed <= progress.total
+  );
+}
 
 function isCodeGraphMaintenanceProgressPhase(value: unknown): value is CodeGraphMaintenanceProgressPhase {
   return (

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -1,6 +1,5 @@
 import {Clock, Context, Crypto, Effect, FileSystem, Layer, Option, Path, Schema} from 'effect';
 import {CommandExecutor, runCommandEffect} from '../effect/command.js';
-import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {SystemInfo} from '../effect/system.js';
 import {
   codeGraphDirectPersistentCapacityProtector,
@@ -9,19 +8,11 @@ import {
 } from './indexer.js';
 import {CodeGraphMaintenanceCoordinator} from './maintenance_coordinator.js';
 import {worktreeOverlayState} from './inventory.js';
+import type {CodeGraphCliPurgeProgress} from './cli_progress.js';
 import {CodeGraphLanguagePackRegistry, type CodeGraphLanguagePackRegistryShape} from './languages/registry.js';
-import {
-  codeGraphLayout,
-  codeGraphMaintenanceLockPath,
-  codeGraphRepositoryLockPath,
-  type CodeGraphLayout,
-} from './layout.js';
-import {
-  awaitCodeGraphWorktreeBuilds,
-  withCodeGraphDatabaseWriteLock,
-  withCodeGraphMaintenanceIntent,
-  withCodeGraphTargetWorktreeLock,
-} from './maintenance_gate.js';
+import {codeGraphLayout, type CodeGraphLayout} from './layout.js';
+import {withCodeGraphTargetWorktreeLock} from './maintenance_gate.js';
+import {purgeCodeGraphRepositoryRoot} from './maintenance.js';
 import {
   recordVerifiedCodeGraphLocalAssociation,
   resolveAndRecordCodeGraphLocalAssociation,
@@ -131,7 +122,11 @@ export class CodeGraphQueryService extends Context.Service<
       interlock?: CodeGraphSharedReadyAttachInterlock,
     ) => Effect.Effect<CodeGraphStatus, unknown>;
     readonly inspect: (options: CodeGraphInspectOptions) => Effect.Effect<CodeGraphQueryResult, unknown>;
-    readonly purge: (threadnoteHome: string, cwd: string) => Effect.Effect<string, unknown>;
+    readonly purge: (
+      home: string,
+      cwd: string,
+      onProgress?: (progress: CodeGraphCliPurgeProgress) => Effect.Effect<void, unknown>,
+    ) => Effect.Effect<string, unknown>;
     readonly status: (
       threadnoteHome: string,
       cwd: string,
@@ -660,43 +655,17 @@ export class CodeGraphQueryService extends Context.Service<
               return result;
             }),
           ),
-        purge: (threadnoteHome, cwd) =>
+        purge: (threadnoteHome, cwd, onProgress) =>
           withRepositoryServices(
             Effect.gen(function* () {
               const identity = yield* resolveRepositoryIdentity(cwd);
               const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
-              const lockOptions = {
-                retryIntervalMilliseconds: 100,
-                staleAfterMilliseconds: 120_000,
-                waitTimeoutMilliseconds: 10 * 60_000,
-              } as const;
-              yield* withExclusiveFileLock(
-                fs,
-                codeGraphMaintenanceLockPath(path, threadnoteHome),
-                lockOptions,
-                withCodeGraphMaintenanceIntent(
-                  threadnoteHome,
-                  withExclusiveFileLock(
-                    fs,
-                    codeGraphRepositoryLockPath(path, threadnoteHome, identity.checkoutId),
-                    lockOptions,
-                    awaitCodeGraphWorktreeBuilds(
-                      threadnoteHome,
-                      identity.checkoutId,
-                      lockOptions.waitTimeoutMilliseconds,
-                    ).pipe(
-                      Effect.andThen(
-                        withCodeGraphDatabaseWriteLock(
-                          threadnoteHome,
-                          identity.checkoutId,
-                          fs.remove(layout.repositoryRoot, {recursive: true, force: true}),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+              return yield* purgeCodeGraphRepositoryRoot(
+                threadnoteHome,
+                identity.checkoutId,
+                layout.repositoryRoot,
+                onProgress,
               );
-              return layout.repositoryRoot;
             }),
           ),
         status: (threadnoteHome, cwd, options) =>

--- a/src/code_graph/storage.ts
+++ b/src/code_graph/storage.ts
@@ -9,7 +9,7 @@ import {
   codeGraphRepositoryLockActive,
   codeGraphWorktreeBuildActive,
   withCodeGraphDatabaseWriteLock,
-  withCodeGraphMaintenanceIntent,
+  withCodeGraphReportedMaintenanceIntent,
 } from './maintenance_gate.js';
 import {CODE_GRAPH_SCHEMA_VERSION, type CodeGraphSnapshot} from './types.js';
 import {
@@ -328,6 +328,7 @@ export const compactCodeGraphStorage = Effect.fn('codeGraph.compactStorage')(fun
     readonly dryRun: boolean;
     readonly force?: boolean;
     readonly interlock?: CodeGraphCompactionInterlock;
+    readonly onProgress?: (phase: 'compacting' | 'inspecting' | 'waiting-builders') => Effect.Effect<void, unknown>;
   },
 ) {
   const fs = yield* FileSystem.FileSystem;
@@ -346,16 +347,25 @@ export const compactCodeGraphStorage = Effect.fn('codeGraph.compactStorage')(fun
       reason,
       reclaimedBytes: 0,
     }) satisfies CodeGraphCompactionSummary;
+  let reportMaintenance: (progress: {
+    readonly completed: number;
+    readonly phase: 'acquiring-gates' | 'retiring-and-cleaning' | 'verifying-graph' | 'waiting-builders';
+    readonly total: number;
+  }) => Effect.Effect<void> = () => Effect.void;
   const checkoutMaintenance = withExclusiveFileLock(
     fs,
     codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
     STORAGE_LOCK_OPTIONS,
     Effect.gen(function* () {
+      yield* options.onProgress?.('waiting-builders') ?? Effect.void;
+      yield* reportMaintenance({completed: 1, phase: 'waiting-builders', total: 3});
       yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, checkoutId, 0);
       return yield* withCodeGraphDatabaseWriteLock(
         threadnoteHome,
         checkoutId,
         Effect.gen(function* () {
+          yield* options.onProgress?.('inspecting') ?? Effect.void;
+          yield* reportMaintenance({completed: 2, phase: 'verifying-graph', total: 3});
           const before = yield* inspectCodeGraphStorage(threadnoteHome, checkoutId, {
             measureFragmentation: true,
             openWhileLocked: true,
@@ -399,6 +409,8 @@ export const compactCodeGraphStorage = Effect.fn('codeGraph.compactStorage')(fun
             } satisfies CodeGraphCompactionSummary;
           }
           yield* verifyCompactionDiskHeadroom(system, path.dirname(databasePath), before);
+          yield* options.onProgress?.('compacting') ?? Effect.void;
+          yield* reportMaintenance({completed: 3, phase: 'retiring-and-cleaning', total: 3});
           yield* vacuumDatabase(databasePath);
           const afterReceipt = yield* readCompactionReceipt(databasePath);
           if (!sameCompactionReceipt(receipt, afterReceipt)) {
@@ -436,7 +448,15 @@ export const compactCodeGraphStorage = Effect.fn('codeGraph.compactStorage')(fun
     fs,
     codeGraphMaintenanceLockPath(path, threadnoteHome),
     STORAGE_LOCK_OPTIONS,
-    withCodeGraphMaintenanceIntent(threadnoteHome, checkoutMaintenance),
+    withCodeGraphReportedMaintenanceIntent(
+      threadnoteHome,
+      {checkoutId, operation: 'graph-maintenance'},
+      {completed: 0, phase: 'acquiring-gates', total: 3},
+      reporter => {
+        reportMaintenance = reporter.progress;
+        return checkoutMaintenance;
+      },
+    ),
   ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed(deferred('active-maintenance'))));
   if (options.dryRun) return yield* maintain;
   const candidate = (opportunityBytes: number) => ({checkoutId, opportunityBytes});

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -94,6 +94,7 @@ export {
   codeGraphExactSnapshotRetirementStatement,
 } from './store_cleanup_core.js';
 export {
+  CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE,
   codeGraphRoutineFileBlobCleanupPageStatement,
   codeGraphRoutineMaterializedShardCleanupPageStatement,
 } from './store_maintenance_core.js';

--- a/src/code_graph/store_maintenance_core.ts
+++ b/src/code_graph/store_maintenance_core.ts
@@ -22,7 +22,7 @@ import {lastStatementChangeCount} from './store_activation_core.js';
 
 const CODE_GRAPH_ROUTINE_EXPIRED_LEASE_PAGE_SIZE = 100;
 
-const CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE = 100;
+export const CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE = 1_000;
 
 /** Fresh facts are written before the durable building snapshot owns its inventory. */
 const CODE_GRAPH_ROUTINE_CACHE_MINIMUM_AGE_MILLISECONDS = 24 * 60 * 60_000;
@@ -643,7 +643,6 @@ const recordSnapshotExtractorGeneration = Effect.fn('codeGraph.recordSnapshotExt
 });
 
 export {
-  CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE,
   BoundedSnapshotLeaseRow,
   boundedSnapshotLeaseProjection,
   recordSnapshotExtractorGeneration,

--- a/src/code_graph/threadnote_ignore.ts
+++ b/src/code_graph/threadnote_ignore.ts
@@ -1,0 +1,93 @@
+import {Effect, FileSystem, Path} from 'effect';
+import {readOptionalText} from './inventory_contained_file.js';
+
+export const THREADNOTE_IGNORE_FILE = '.threadnoteignore';
+export const THREADNOTE_IGNORE_LOCAL_FILE = '.threadnoteignore.local';
+
+export interface CompiledIgnoreRule {
+  readonly ignored: boolean;
+  readonly pattern: RegExp;
+  readonly source: 'committed' | 'local';
+}
+
+export interface ThreadnoteIgnoreSources {
+  readonly committed: string;
+  readonly local: string;
+}
+
+export function isThreadnoteIgnorePath(repositoryPath: string): boolean {
+  return repositoryPath === THREADNOTE_IGNORE_FILE || repositoryPath === THREADNOTE_IGNORE_LOCAL_FILE;
+}
+
+export function isOverlayAdmissionControlPath(repositoryPath: string): boolean {
+  return isThreadnoteIgnorePath(repositoryPath) || /(?:^|\/)\.gitignore$/.test(repositoryPath);
+}
+
+export const readThreadnoteIgnoreSources = Effect.fn('codeGraph.readThreadnoteIgnoreSources')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  repoRoot: string,
+) {
+  const [committed, local] = yield* Effect.all(
+    [
+      readOptionalText(fs, path.join(repoRoot, THREADNOTE_IGNORE_FILE)),
+      readOptionalText(fs, path.join(repoRoot, THREADNOTE_IGNORE_LOCAL_FILE)),
+    ],
+    {concurrency: 2},
+  );
+  return {committed, local} satisfies ThreadnoteIgnoreSources;
+});
+
+export function compileThreadnoteIgnore(content: string, localContent = ''): readonly CompiledIgnoreRule[] {
+  return [...compileIgnoreContent(content, 'committed'), ...compileIgnoreContent(localContent, 'local')];
+}
+
+export function isIgnoredByThreadnote(path: string, rules: readonly CompiledIgnoreRule[]): boolean {
+  let committed = false;
+  let local = false;
+  for (const rule of rules) {
+    if (!rule.pattern.test(path)) continue;
+    if (rule.source === 'local') local = rule.ignored;
+    else committed = rule.ignored;
+  }
+  return committed || local;
+}
+
+export function emptyThreadnoteIgnoreAdmissionPath(repositoryPath: string, sources: ThreadnoteIgnoreSources): boolean {
+  if (repositoryPath === THREADNOTE_IGNORE_FILE) return sources.committed.length === 0;
+  if (repositoryPath === THREADNOTE_IGNORE_LOCAL_FILE) return sources.local.length === 0;
+  return false;
+}
+
+function compileIgnoreContent(content: string, source: CompiledIgnoreRule['source']): readonly CompiledIgnoreRule[] {
+  const rules: CompiledIgnoreRule[] = [];
+  for (const rawLine of content.split(/\r?\n/)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const negated = trimmed.startsWith('!');
+    const pattern = normalizeRepositoryPath(negated ? trimmed.slice(1) : trimmed);
+    if (!pattern) continue;
+    const compiled = compileIgnorePattern(pattern);
+    if (compiled) rules.push({ignored: !negated, pattern: compiled, source});
+  }
+  return rules;
+}
+
+function compileIgnorePattern(pattern: string): RegExp | undefined {
+  const directoryPattern = pattern.endsWith('/');
+  const normalized = pattern.replace(/^\/+|\/+$/g, '');
+  if (!normalized) return undefined;
+  const escaped = normalized
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replaceAll('**', '\u0000')
+    .replaceAll('*', '[^/]*')
+    .replaceAll('?', '[^/]')
+    .replaceAll('\u0000', '.*');
+  const prefix = normalized.includes('/') ? '^' : '(?:^|/)';
+  const suffix = directoryPattern ? '(?:/|$)' : '$';
+  return new RegExp(`${prefix}${escaped}${suffix}`, 'i');
+}
+
+function normalizeRepositoryPath(value: string): string {
+  return value.replace(/^\.\/+/, '');
+}

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -1167,6 +1167,10 @@ function relevantWatchPath(path: Path.Path, cwd: string, eventPath: string): boo
   }
   const segments = relative.split(path.sep);
   return !segments.some(
-    segment => segment.startsWith('.') && segment !== '.gitignore' && segment !== '.threadnoteignore',
+    segment =>
+      segment.startsWith('.') &&
+      segment !== '.gitignore' &&
+      segment !== '.threadnoteignore' &&
+      segment !== '.threadnoteignore.local',
   );
 }

--- a/src/effect/console.ts
+++ b/src/effect/console.ts
@@ -1,5 +1,6 @@
 import {Console, Effect} from 'effect';
 import {CliOutput} from './cli_output.js';
+import {SystemInfo} from './system.js';
 
 function capturingConsole(parent: Console.Console, lines: string[]): Console.Console {
   const append = (...args: readonly unknown[]): void => {
@@ -41,6 +42,24 @@ export function captureConsole<A, E, R>(
       Effect.provideService(Console.Console, service),
       Effect.provideService(CliOutput, cliOutput),
       Effect.map(value => ({output: lines.join('\n'), value})),
+    );
+  });
+}
+
+/** Capture stdout while suppressing CLI progress indicators. */
+export function captureConsoleWithoutProgress<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<{readonly output: string; readonly value: A}, E, R | SystemInfo> {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    return yield* captureConsole(effect).pipe(
+      Effect.provideService(
+        SystemInfo,
+        SystemInfo.of({
+          ...system,
+          environment: () => ({...system.environment(), THREADNOTE_NO_PROGRESS: '1'}),
+        }),
+      ),
     );
   });
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -66,9 +66,10 @@ import {
 import {
   codeGraphDoctorCheck,
   type CodeGraphMaintenanceProgress,
+  type CodeGraphRepairCompletion,
   repairCodeGraphIndexes,
 } from './code_graph/maintenance.js';
-import {formatCodeGraphRepairProgressLine} from './code_graph/cli_progress.js';
+import {formatCodeGraphDoctorProgressLine, formatCodeGraphRepairProgressLine} from './code_graph/cli_progress.js';
 import {
   isThreadnoteStorageLayoutReceipt,
   threadnoteStorageLayout,
@@ -116,22 +117,19 @@ interface RunDoctorOptions extends DoctorOptions {
 
 interface CollectDoctorOptions extends RunDoctorOptions {
   readonly onCodeGraphProgress?: (progress: CodeGraphMaintenanceProgress) => Effect.Effect<void, unknown>;
+  readonly withCodeGraphProgressLine?: boolean;
 }
 
 export const runDoctor = Effect.fn('lifecycle.doctor')(function* (config: RuntimeConfig, options: RunDoctorOptions) {
   const system = yield* SystemInfo;
   yield* Console.log('Running Threadnote doctor checks.');
-  const checks = yield* withProgressLine(
-    formatCodeGraphRepairProgressLine({current: 0, phase: 'checking', total: 1}),
-    update =>
-      collectDoctorChecks(
-        config,
-        {
-          ...options,
-          onCodeGraphProgress: progress => update(formatCodeGraphRepairProgressLine(progress)),
-        },
-        system.platform,
-      ),
+  const checks = yield* collectDoctorChecks(
+    config,
+    {
+      ...options,
+      withCodeGraphProgressLine: true,
+    },
+    system.platform,
   );
   for (const check of checks) {
     yield* Console.log(`${formatStatus(check.status)} ${check.name}: ${check.detail}`);
@@ -205,7 +203,15 @@ export const collectDoctorChecks = Effect.fn('lifecycle.collectDoctorChecks')(fu
     yield* safeDoctorCheck('vector recall index', vectorRecallIndexCheck(config, lexicalStatus)),
     yield* safeDoctorCheck(
       'native code graph',
-      codeGraphDoctorCheck(config.agentContextHome, options.onCodeGraphProgress, options.codeGraphCheck),
+      options.withCodeGraphProgressLine === true && options.codeGraphCheck === undefined
+        ? withProgressLine(formatCodeGraphDoctorProgressLine({current: 0, phase: 'checking', total: 1}), update =>
+            codeGraphDoctorCheck(
+              config.agentContextHome,
+              progress => update(formatCodeGraphDoctorProgressLine(progress)),
+              options.codeGraphCheck,
+            ),
+          )
+        : codeGraphDoctorCheck(config.agentContextHome, options.onCodeGraphProgress, options.codeGraphCheck),
     ),
     yield* safeDoctorCheck('memory project consistency', memoryProjectConsistencyCheck(config)),
     yield* safeDoctorCheck('deferred code anchors', deferredCodeAnchorDoctorCheck(config)),
@@ -435,6 +441,7 @@ export const runRepair = Effect.fn('lifecycle.repair')(function* (config: Runtim
       yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun});
     }
   }
+  let completion: CodeGraphRepairCompletion | undefined;
   yield* withProgressLine(
     formatCodeGraphRepairProgressLine({current: 0, phase: 'checking', total: 1}, dryRun),
     update =>
@@ -442,10 +449,7 @@ export const runRepair = Effect.fn('lifecycle.repair')(function* (config: Runtim
         config.agentContextHome,
         dryRun,
         progress => update(formatCodeGraphRepairProgressLine(progress, dryRun)),
-        completion =>
-          Console.log(codeGraphRepairSummaryMessage(completion.summary, dryRun)).pipe(
-            Effect.andThen(runDoctor(config, {codeGraphCheck: completion.doctorCheck, dryRun, strict: false})),
-          ),
+        result => Effect.sync(() => void (completion = result)),
         {migrateSchema: true, mode: options.deep === true ? 'deep' : 'quick'},
       ),
   ).pipe(
@@ -453,6 +457,10 @@ export const runRepair = Effect.fn('lifecycle.repair')(function* (config: Runtim
       LifecycleOperationError.make({message: `Native code graph repair failed: ${errorMessage(cause)}`}),
     ),
   );
+  if (completion !== undefined) {
+    yield* Console.log(codeGraphRepairSummaryMessage(completion.summary, dryRun));
+    yield* runDoctor(config, {codeGraphCheck: completion.doctorCheck, dryRun, strict: false});
+  }
   if (options.postUpdate !== false) {
     yield* maybeRunPostUpdateAfterRepair(config, {dryRun});
   }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -10,7 +10,7 @@ import {
   repairAgentIntegrations,
 } from './agent_integration/index.js';
 import {type AgentIntegrationRegistry, withAgentIntegrationLock} from './agent_integration/registry.js';
-import {startProgress} from './cli_ui.js';
+import {startProgress, withProgressLine} from './cli_ui.js';
 import {commandShimCheck, installCommandShim, removeCommandShim} from './command-shim.js';
 import {sha256FileHex} from './effect/digest.js';
 import {hasManagedClaudeHooks, runHooksInstall} from './hooks.js';
@@ -68,6 +68,7 @@ import {
   type CodeGraphMaintenanceProgress,
   repairCodeGraphIndexes,
 } from './code_graph/maintenance.js';
+import {formatCodeGraphRepairProgressLine} from './code_graph/cli_progress.js';
 import {
   isThreadnoteStorageLayoutReceipt,
   threadnoteStorageLayout,
@@ -120,13 +121,17 @@ interface CollectDoctorOptions extends RunDoctorOptions {
 export const runDoctor = Effect.fn('lifecycle.doctor')(function* (config: RuntimeConfig, options: RunDoctorOptions) {
   const system = yield* SystemInfo;
   yield* Console.log('Running Threadnote doctor checks.');
-  const checks = yield* collectDoctorChecks(
-    config,
-    {
-      ...options,
-      onCodeGraphProgress: progress => Console.log(codeGraphMaintenanceProgressMessage(progress)),
-    },
-    system.platform,
+  const checks = yield* withProgressLine(
+    formatCodeGraphRepairProgressLine({current: 0, phase: 'checking', total: 1}),
+    update =>
+      collectDoctorChecks(
+        config,
+        {
+          ...options,
+          onCodeGraphProgress: progress => update(formatCodeGraphRepairProgressLine(progress)),
+        },
+        system.platform,
+      ),
   );
   for (const check of checks) {
     yield* Console.log(`${formatStatus(check.status)} ${check.name}: ${check.detail}`);
@@ -430,15 +435,19 @@ export const runRepair = Effect.fn('lifecycle.repair')(function* (config: Runtim
       yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun});
     }
   }
-  yield* repairCodeGraphIndexes(
-    config.agentContextHome,
-    dryRun,
-    progress => Console.log(codeGraphMaintenanceProgressMessage(progress, dryRun)),
-    completion =>
-      Console.log(codeGraphRepairSummaryMessage(completion.summary, dryRun)).pipe(
-        Effect.andThen(runDoctor(config, {codeGraphCheck: completion.doctorCheck, dryRun, strict: false})),
+  yield* withProgressLine(
+    formatCodeGraphRepairProgressLine({current: 0, phase: 'checking', total: 1}, dryRun),
+    update =>
+      repairCodeGraphIndexes(
+        config.agentContextHome,
+        dryRun,
+        progress => update(formatCodeGraphRepairProgressLine(progress, dryRun)),
+        completion =>
+          Console.log(codeGraphRepairSummaryMessage(completion.summary, dryRun)).pipe(
+            Effect.andThen(runDoctor(config, {codeGraphCheck: completion.doctorCheck, dryRun, strict: false})),
+          ),
+        {migrateSchema: true, mode: options.deep === true ? 'deep' : 'quick'},
       ),
-    {migrateSchema: true, mode: options.deep === true ? 'deep' : 'quick'},
   ).pipe(
     Effect.mapError(cause =>
       LifecycleOperationError.make({message: `Native code graph repair failed: ${errorMessage(cause)}`}),
@@ -557,29 +566,6 @@ function recallProgressMessage(progress: RecallIndexProgress): string {
     return `Building lexical recall index: ${progress.completed}/${progress.total} changed document(s) indexed (${percentage}%; ${progress.scanned} canonical document(s) scanned).`;
   }
   return `Writing lexical recall postings: ${progress.completed}/${progress.total} changed document(s) (${percentage}%), ${progress.removed} stale document(s) removed.`;
-}
-
-function codeGraphMaintenanceProgressMessage(progress: CodeGraphMaintenanceProgress, dryRun = false): string {
-  const database = `native code graph database ${progress.current}/${progress.total}`;
-  switch (progress.phase) {
-    case 'checking':
-      return `Checking ${database}.`;
-    case 'cleaning-snapshots':
-      return `${dryRun ? 'Would clean' : 'Cleaning'} ${progress.snapshots ?? 0} incomplete snapshot(s) from ${database}.`;
-    case 'cleaning-vectors':
-      return `Checking temporary graph state for ${database}.`;
-    case 'deferred':
-      if (progress.reason === 'active-build') {
-        return `Deferred ${database}: an active graph build owns the checkout; update and repair will not wait for it.`;
-      }
-      return progress.reason === 'schema-upgrade-on-use'
-        ? `Deferred ${database}: ready snapshots remain usable while background schema migration retries.`
-        : `Deferred ${database}: run \`threadnote repair --deep\` when a full derived-store check is convenient.`;
-    case 'discarding':
-      return `${dryRun ? 'Would discard' : 'Discarding'} unreadable derived ${database}.`;
-    case 'migrating-schema':
-      return `${dryRun ? 'Would migrate' : 'Migrating'} the persistent schema for ${database}.`;
-  }
 }
 
 function codeGraphRepairSummaryMessage(

--- a/src/manager/graph.tsx
+++ b/src/manager/graph.tsx
@@ -19,6 +19,7 @@ export {
   graphDiagnosticsRequiresCatalogRefresh,
   graphDisplayEdges,
   graphLocalAssociationText,
+  graphMaintenanceRemainingMilliseconds,
   graphMaintenanceStatusLabel,
   mergeGraphCatalogStatus,
   graphNodeDetailRequestIsCurrent,

--- a/src/manager/graph_model.ts
+++ b/src/manager/graph_model.ts
@@ -4,6 +4,7 @@ import type {CodeGraphLocalDiagnosticsReport} from '../code_graph/diagnostics.js
 import type {CodeGraphLocalAssociation} from '../code_graph/local_provenance.js';
 import type {CodeGraphMaintenanceStatus} from '../code_graph/maintenance_gate.js';
 import type {ManagerGraphStorageSummary} from '../code_graph/manager_status.js';
+import {codeGraphFailedBuildStatusCurrent} from '../code_graph/build_status_validation.js';
 import {compareCodeUnits} from '../code_graph/ordering.js';
 import {
   MANAGER_GRAPH_DEFAULT_EDGE_LIMIT,
@@ -446,7 +447,10 @@ export function graphBuildIsActive(build: GraphBuildStatus): boolean {
 }
 
 export function graphBuildShouldDisplay(build: GraphBuildStatus): boolean {
-  return build.state === 'failed' || graphBuildIsActive(build);
+  return (
+    graphBuildIsActive(build) ||
+    (build.state === 'failed' && codeGraphFailedBuildStatusCurrent(build.observation.heartbeatAgeMilliseconds))
+  );
 }
 
 /** Keep status banners anchored to a worktree instead of moving as progress timestamps change. */

--- a/src/manager/graph_model.ts
+++ b/src/manager/graph_model.ts
@@ -661,15 +661,40 @@ export type GraphStorageSummary = ManagerGraphStorageSummary;
 export function graphMaintenanceStatusLabel(status: CodeGraphMaintenanceStatus): string {
   const operation = status.operation === 'selected-snapshot-purge' ? 'Selected snapshot purge' : 'Graph maintenance';
   const phases: Record<CodeGraphMaintenanceStatus['phase'], string> = {
-    'acquiring-gates': 'acquiring safety gates',
-    'retiring-and-cleaning': 'retiring snapshot and advancing cleanup',
+    'acquiring-gates': status.operation === 'selected-snapshot-purge' ? 'acquiring safety gates' : 'acquiring locks',
+    'retiring-and-cleaning':
+      status.operation === 'selected-snapshot-purge'
+        ? 'retiring snapshot and advancing cleanup'
+        : 'cleaning derived state',
     'status-unavailable': 'working; detailed status unavailable',
-    'verifying-graph': 'rechecking graph safety evidence',
-    'verifying-vectors': 'rechecking vector safety evidence',
+    'verifying-graph':
+      status.operation === 'selected-snapshot-purge' ? 'rechecking graph safety evidence' : 'verifying graph store',
+    'verifying-vectors':
+      status.operation === 'selected-snapshot-purge' ? 'rechecking vector safety evidence' : 'verifying related files',
     'waiting-builders': 'waiting for graph builders',
     working: 'working',
   };
   return `${operation} · ${phases[status.phase]}`;
+}
+
+export function graphMaintenanceRemainingMilliseconds(
+  status: Pick<CodeGraphMaintenanceStatus, 'completed' | 'startedAt' | 'total'>,
+  nowMilliseconds: number,
+): number | undefined {
+  if (
+    status.completed === undefined ||
+    status.total === undefined ||
+    status.startedAt === undefined ||
+    status.total <= 0 ||
+    status.completed <= 0 ||
+    status.completed > status.total
+  ) {
+    return undefined;
+  }
+  if (status.completed === status.total) return 0;
+  const elapsed = nowMilliseconds - Date.parse(status.startedAt);
+  if (!Number.isFinite(elapsed) || elapsed < 0) return undefined;
+  return Math.round((elapsed / status.completed) * (status.total - status.completed));
 }
 
 export function graphCompletedBuildResultIdentity(build: GraphBuildStatus): string | undefined {

--- a/src/manager/graph_panels.tsx
+++ b/src/manager/graph_panels.tsx
@@ -16,6 +16,7 @@ import {
   graphBuildConcurrencyState,
   graphBuildTarget,
   graphLocalAssociationText,
+  graphMaintenanceRemainingMilliseconds,
   graphMaintenanceStatusLabel,
   graphRelationshipCountLabel,
   graphRelationshipSampleLabel,
@@ -1020,10 +1021,12 @@ export function GraphMaintenanceProgress(props: {
   const elapsed = status.startedAt === undefined ? undefined : Math.max(0, Date.now() - Date.parse(status.startedAt));
   const lastUpdate =
     status.updatedAt === undefined ? undefined : Math.max(0, Date.now() - Date.parse(status.updatedAt));
+  const remaining = graphMaintenanceRemainingMilliseconds(status, Date.now());
   const percentage =
     status.completed !== undefined && status.total !== undefined && status.total > 0
       ? Math.max(0, Math.min(100, (status.completed / status.total) * 100))
       : undefined;
+  const unit = status.operation === 'selected-snapshot-purge' ? 'safety phases' : 'phases';
   return (
     <div className="graph-build-status graph-maintenance-status" aria-live="polite">
       <article className="graph-build-card is-running is-active">
@@ -1051,7 +1054,8 @@ export function GraphMaintenanceProgress(props: {
         <p>
           {status.completed === undefined || status.total === undefined
             ? 'Waiting for the next maintenance phase update'
-            : `${status.completed.toLocaleString()} / ${status.total.toLocaleString()} safety phases`}
+            : `${status.completed.toLocaleString()} / ${status.total.toLocaleString()} ${unit}`}
+          {remaining === undefined ? '' : ` · ETA ${formatBuildDuration(remaining)}`}
           {lastUpdate === undefined ? '' : ` · last update ${formatBuildDuration(lastUpdate)} ago`}
         </p>
       </article>

--- a/src/manager/server.ts
+++ b/src/manager/server.ts
@@ -27,7 +27,7 @@ import {
   runNativeAiConsolidation,
 } from '../effect/ai/consolidator.js';
 import {runCommandEffect} from '../effect/command.js';
-import {captureConsole} from '../effect/console.js';
+import {captureConsoleWithoutProgress} from '../effect/console.js';
 import {withMemoryUriLocks} from '../effect/memory_lock.js';
 import {ResourceStore} from '../effect/resource-store.js';
 import type {ApplicationServices} from '../effect/runtime.js';
@@ -1581,7 +1581,7 @@ const runCaptured = Effect.fn('manager.runCaptured')(function* (
   action: () => ManagerOperation<void>,
   _runEffect?: ManagerEffectPromise,
 ) {
-  const captured = yield* captureConsole(action());
+  const captured = yield* captureConsoleWithoutProgress(action());
   return {output: captured.output};
 });
 

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -202,10 +202,8 @@ describe('built self-contained distribution', () => {
       String(coldGraphReadTimeoutMs),
     ]);
     expect(firstQuery).toContain('Scanning repository source from Git.');
-    expect(firstQuery).toMatch(
-      /Scanning · \d+\/\d+ eligible files · \d+ accepted · \d+ content skipped · \d+ excluded/,
-    );
-    expect(firstQuery).toMatch(/Materializing · \d+\/\d+ files · \d+ reused/);
+    expect(firstQuery).toMatch(/Scanning · \d+\/\d+ \(\d+%\) files/);
+    expect(firstQuery).toMatch(/Materializing · \d+\/\d+ \(\d+%\) files/);
     expect(firstQuery).toContain('Code graph: code-graph-repository');
     expect(firstQuery).toContain('withExclusiveFileLock');
 

--- a/test/integration/code-graph.inventory-policy.test.ts
+++ b/test/integration/code-graph.inventory-policy.test.ts
@@ -212,6 +212,44 @@ describe('code graph inventory admission policy', () => {
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
+  effectIt.effect('unions committed and checkout-local Threadnote ignore files during inventory', () =>
+    Effect.gen(function* () {
+      const root = mkdtempSync(join(tmpdir(), 'threadnote-inventory-ignore-local-'));
+      roots.push(root);
+      git(root, ['init', '-q']);
+      mkdirSync(join(root, 'src'), {recursive: true});
+      writeFileSync(join(root, 'src', 'a.ts'), 'export const a = 1;\n');
+      writeFileSync(join(root, 'src', 'b.ts'), 'export const b = 1;\n');
+      writeFileSync(join(root, 'src', 'c.ts'), 'export const c = 1;\n');
+      writeFileSync(join(root, '.threadnoteignore'), 'src/a.ts\n');
+      writeFileSync(join(root, '.threadnoteignore.local'), 'src/b.ts\n');
+      git(root, ['add', '.threadnoteignore', 'src']);
+      git(root, [
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+
+      const identity = yield* resolveRepositoryIdentity(root);
+      const preview = yield* previewCodeGraphInventory(identity);
+      const ignored = preview.groups.find(
+        candidate => candidate.reason === 'threadnote-ignore' && candidate.language === 'typescript',
+      );
+      const admitted = preview.groups.find(
+        candidate => candidate.reason === 'admitted' && candidate.language === 'typescript',
+      );
+      expect(ignored).toMatchObject({disposition: 'skipped', files: 2});
+      expect(admitted).toMatchObject({disposition: 'eligible', files: 1});
+
+      const inventoried = yield* inventoryRepository(identity);
+      expect(inventoried.files.map(file => file.path)).toEqual(['src/c.ts']);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
   it('bounds Git ignore checks and stable metadata inspection to relevant changed paths', async () => {
     const root = mkdtempSync(join(tmpdir(), 'threadnote-inventory-policy-changed-paths-'));
     roots.push(root);

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -5839,7 +5839,8 @@ describe('native code graph lifecycle', () => {
       }),
     );
 
-    expect(output.doctor).toMatch(/Repairing · checking \d+\/\d+ databases/);
+    expect(output.doctor).toMatch(/Checking · checking \d+\/\d+ databases/);
+    expect(output.doctor).not.toMatch(/Repairing · checking \d+\/\d+ databases/);
     expect(output.doctor).not.toMatch(/Checking native code graph database \d+\/2\./);
     expect(output.doctor).toContain(
       'FAIL native code graph: 2 database(s); 1 ready snapshot(s); 1 incomplete snapshot(s); ' +
@@ -5855,6 +5856,9 @@ describe('native code graph lifecycle', () => {
     expect(output.repair).toContain(
       'WARN native code graph: 2 database(s); 1 ready snapshot(s); 0 incomplete snapshot(s); ' +
         '2 database maintenance check(s) deferred',
+    );
+    expect(output.repair.indexOf('Running Threadnote doctor checks.')).toBeGreaterThan(
+      output.repair.search(/Would repair \d+ native code graph database/),
     );
   });
 

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -5839,17 +5839,15 @@ describe('native code graph lifecycle', () => {
       }),
     );
 
-    expect(output.doctor.match(/Checking native code graph database [12]\/2\./g)).toHaveLength(2);
+    expect(output.doctor).toMatch(/Repairing · checking \d+\/\d+ databases/);
+    expect(output.doctor).not.toMatch(/Checking native code graph database \d+\/2\./);
     expect(output.doctor).toContain(
       'FAIL native code graph: 2 database(s); 1 ready snapshot(s); 1 incomplete snapshot(s); ' +
         '1 database(s) need a disposable rebuild',
     );
-    expect(output.repair.match(/Checking native code graph database [12]\/2\./g)).toHaveLength(2);
-    expect(
-      output.repair.match(
-        /Deferred native code graph database [12]\/2: run `threadnote repair --deep` when a full derived-store check is convenient\./g,
-      ),
-    ).toHaveLength(2);
+    expect(output.repair).toMatch(/Would repair · /);
+    expect(output.repair).not.toMatch(/Checking native code graph database \d+\/2\./);
+    expect(output.repair).toMatch(/Would repair · deferred \d+\/2 databases/);
     expect(output.repair).toContain(
       'Would repair 2 native code graph database(s): 2 deferred, 0 disposable rebuild(s), 0 incomplete snapshot(s), ' +
         '0 temporary graph file(s).',

--- a/test/unit/cli-ui.progress.test.ts
+++ b/test/unit/cli-ui.progress.test.ts
@@ -372,6 +372,57 @@ describe('CLI progress indicator', () => {
       ]);
     }),
   );
+
+  effectIt.effect('keeps captured result lines when progress is disabled', () =>
+    Effect.gen(function* () {
+      const system = yield* SystemInfo.pipe(provideTestLayer(ApplicationLayer));
+      const quietSystem = SystemInfo.of({
+        ...system,
+        environment: () => ({THREADNOTE_NO_PROGRESS: '1'}),
+        stdoutIsTTY: false,
+      });
+
+      const captured = yield* captureConsole(
+        Effect.acquireUseRelease(
+          startProgress('Would purge · acquiring locks'),
+          progress =>
+            Effect.gen(function* () {
+              yield* progress.update('Would purge · deleting files');
+              yield* Console.log('Would remove derived code graph index for checkout abcdef123456.');
+            }),
+          progress => progress.stop,
+        ),
+      ).pipe(Effect.provideService(SystemInfo, quietSystem), provideTestLayer(ApplicationLayer));
+
+      expect(captured.output).toBe('Would remove derived code graph index for checkout abcdef123456.');
+    }),
+  );
+
+  effectIt.effect.prop(
+    'disabled progress emits no console lines',
+    {
+      messages: fc.array(fc.string({maxLength: 40, minLength: 1}), {maxLength: 8, minLength: 1}),
+    },
+    ({messages}) =>
+      Effect.gen(function* () {
+        const system = yield* SystemInfo.pipe(provideTestLayer(ApplicationLayer));
+        const quietSystem = SystemInfo.of({
+          ...system,
+          environment: () => ({THREADNOTE_NO_PROGRESS: '1'}),
+          stdoutIsTTY: false,
+        });
+        const [initial = '', ...updates] = messages;
+        const captured = yield* captureConsole(
+          Effect.acquireUseRelease(
+            startProgress(initial),
+            progress => Effect.forEach(updates, message => progress.update(message), {discard: true}),
+            progress => progress.stop,
+          ),
+        ).pipe(Effect.provideService(SystemInfo, quietSystem), provideTestLayer(ApplicationLayer));
+        expect(captured.output).toBe('');
+      }),
+    {fastCheck: {numRuns: 40}},
+  );
 });
 
 function orderedCliOutput(events: string[]) {

--- a/test/unit/cli-ui.progress.test.ts
+++ b/test/unit/cli-ui.progress.test.ts
@@ -3,7 +3,7 @@ import {provideTestLayer} from '../helpers/effect-layer.js';
 import {Console, Effect, Terminal} from 'effect';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
-import {promptForSelection, startProgress} from '../../src/cli_ui.js';
+import {clipInteractiveProgressText, promptForSelection, startProgress} from '../../src/cli_ui.js';
 import {CliOutput, makeQueuedCliWriter, withCliOutputConsole} from '../../src/effect/cli_output.js';
 import {captureConsole} from '../../src/effect/console.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
@@ -213,6 +213,56 @@ describe('CLI progress indicator', () => {
       expect(displays.at(-1)).toBe('\r\u001b[2K');
     }),
   );
+
+  effectIt.effect('clips interactive TTY progress to the terminal width and skips unchanged updates', () =>
+    Effect.gen(function* () {
+      const displays: string[] = [];
+      const system = yield* SystemInfo.pipe(provideTestLayer(ApplicationLayer));
+      const interactiveSystem = SystemInfo.of({
+        ...system,
+        environment: () => ({}),
+        stdoutIsTTY: true,
+      });
+      const terminal = Terminal.make({
+        columns: Effect.succeed(24),
+        display: text =>
+          Effect.sync(() => {
+            displays.push(text);
+          }),
+        readInput: Effect.never,
+        readLine: Effect.never,
+        rows: Effect.succeed(40),
+      });
+      const output = orderedCliOutput([]);
+      const longMessage = 'Scanning · 12/345 files · this path must not wrap onto another row';
+
+      yield* Effect.acquireUseRelease(
+        startProgress(longMessage),
+        progress =>
+          Effect.gen(function* () {
+            const afterStart = displays.length;
+            yield* progress.update(longMessage);
+            expect(displays.length).toBe(afterStart);
+            yield* progress.update(`${longMessage} · next`);
+          }),
+        progress => progress.stop,
+      ).pipe(
+        Effect.provideService(CliOutput, output),
+        Effect.provideService(SystemInfo, interactiveSystem),
+        Effect.provideService(Terminal.Terminal, terminal),
+      );
+
+      expect(displays.some(display => display.includes('\n'))).toBe(false);
+      expect(displays.some(display => display.includes('…'))).toBe(true);
+      expect(displays.every(display => !display.includes('must not wrap'))).toBe(true);
+    }),
+  );
+
+  it('clips rewritten progress text to one terminal row', () => {
+    expect(clipInteractiveProgressText('short', 80)).toBe('short');
+    expect(clipInteractiveProgressText('abcdefghijklmnopqrstuvwxyz', 20).endsWith('…')).toBe(true);
+    expect(Array.from(clipInteractiveProgressText('abcdefghijklmnopqrstuvwxyz', 20)).length).toBeLessThanOrEqual(16);
+  });
 
   effectIt.effect('flushes queued headings before an interactive terminal frame', () =>
     Effect.gen(function* () {

--- a/test/unit/cli-ui.progress.test.ts
+++ b/test/unit/cli-ui.progress.test.ts
@@ -262,6 +262,19 @@ describe('CLI progress indicator', () => {
     expect(clipInteractiveProgressText('short', 80)).toBe('short');
     expect(clipInteractiveProgressText('abcdefghijklmnopqrstuvwxyz', 20).endsWith('…')).toBe(true);
     expect(Array.from(clipInteractiveProgressText('abcdefghijklmnopqrstuvwxyz', 20)).length).toBeLessThanOrEqual(16);
+    expect(Array.from(clipInteractiveProgressText('abcdefghijklmnopqrstuvwxyz', 10)).length).toBeLessThanOrEqual(6);
+    fc.assert(
+      fc.property(fc.integer({max: 200, min: 1}), fc.string({maxLength: 80}), (columns, text) => {
+        const clipped = clipInteractiveProgressText(text, columns);
+        const budget = Math.max(1, Math.floor(columns) - 4);
+        const source = Array.from(text);
+        const rendered = Array.from(clipped);
+        if (source.length <= budget) expect(clipped).toBe(text);
+        else expect(rendered.length).toBeLessThanOrEqual(budget);
+        expect(clipped.includes('\n') || clipped.includes('\r')).toBe(false);
+      }),
+      {numRuns: 40},
+    );
   });
 
   effectIt.effect('flushes queued headings before an interactive terminal frame', () =>

--- a/test/unit/code-graph.build-status-bounded.test.ts
+++ b/test/unit/code-graph.build-status-bounded.test.ts
@@ -3,18 +3,24 @@ import * as BunServices from '@effect/platform-bun/BunServices';
 import {it as effectIt} from '@effect/vitest';
 import {Effect, FileSystem, Layer, Path} from 'effect';
 import * as FC from 'effect/testing/FastCheck';
+import {TestClock} from 'effect/testing';
 import {describe, expect} from 'vitest';
 import {
   CODE_GRAPH_BUILD_HISTORY_DIRECTORY_ENTRY_LIMIT,
   CODE_GRAPH_BUILD_HISTORY_STATUS_LIMIT,
   type CodeGraphBuildState,
   type CodeGraphBuildStatus,
+  type ObservedCodeGraphBuildStatus,
   codeGraphBuildHistoryInventory,
   maintainCodeGraphBuildHistoryUnit,
   makeCodeGraphBuildReporter,
   pruneCodeGraphBuildHistoryUnit,
   readAllCodeGraphBuildStatuses,
 } from '../../src/code_graph/build_status.js';
+import {
+  CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS,
+  codeGraphFailedBuildStatusRemovable,
+} from '../../src/code_graph/build_status_validation.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {
   CODE_GRAPH_EXTRACTOR_SET_VERSION,
@@ -88,6 +94,55 @@ describe('bounded code graph build-status maintenance', () => {
           });
           expect(yield* fs.exists(path.join(directory, `${status.buildId}.json`))).toBe(false);
           expect(yield* fs.exists(path.join(directory, `${status.buildId}.manager-context`))).toBe(false);
+        }),
+      ),
+    );
+
+    it.effect('removes one expired failed receipt without requiring a successor reporter', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-build-history-expired-failed-'});
+          const identity = fixtureIdentity(home);
+          const layout = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId);
+          const directory = path.join(layout.repositoryRoot, 'build-status', identity.worktreeId);
+          yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+          const status = fixtureStatus(identity, 'a'.repeat(32), 0, 'failed');
+          yield* writeStatusPair(fs, path, directory, status);
+          yield* TestClock.setTime(
+            Date.parse(status.timestamps.completedAt!) + CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS + 1,
+          );
+
+          expect(yield* maintainCodeGraphBuildHistoryUnit(layout, identity.worktreeId)).toEqual({
+            cursorToken: 'bh1:r',
+            state: 'progress',
+          });
+          expect(yield* fs.exists(path.join(directory, `${status.buildId}.json`))).toBe(false);
+          expect(yield* fs.exists(path.join(directory, `${status.buildId}.manager-context`))).toBe(false);
+        }),
+      ),
+    );
+
+    it.effect('preserves a failed receipt until its retention window elapses', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-build-history-recent-failed-'});
+          const identity = fixtureIdentity(home);
+          const layout = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId);
+          const directory = path.join(layout.repositoryRoot, 'build-status', identity.worktreeId);
+          yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+          const status = fixtureStatus(identity, 'a'.repeat(32), 0, 'failed');
+          yield* writeStatusPair(fs, path, directory, status);
+          yield* TestClock.setTime(
+            Date.parse(status.timestamps.completedAt!) + CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS,
+          );
+
+          expect(yield* maintainCodeGraphBuildHistoryUnit(layout, identity.worktreeId)).toEqual({state: 'complete'});
+          expect(yield* fs.exists(path.join(directory, `${status.buildId}.json`))).toBe(true);
+          expect(yield* fs.exists(path.join(directory, `${status.buildId}.manager-context`))).toBe(true);
         }),
       ),
     );
@@ -535,6 +590,26 @@ describe('bounded code graph build-status maintenance', () => {
     );
 
     it.effect.prop(
+      'failed receipts are removable exactly after a finite age exceeds retention and are not protected',
+      {
+        age: FC.integer({max: CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS * 2, min: 0}),
+        pin: FC.boolean(),
+      },
+      ({age, pin}) =>
+        Effect.sync(() => {
+          const status = observedFailedStatus(age);
+          expect(codeGraphFailedBuildStatusRemovable(status, pin ? status.buildId : undefined)).toBe(
+            !pin && age > CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS,
+          );
+          expect(codeGraphFailedBuildStatusRemovable({...status, state: 'completed'}, undefined)).toBe(false);
+          expect(codeGraphFailedBuildStatusRemovable(observedFailedStatus(Number.POSITIVE_INFINITY), undefined)).toBe(
+            false,
+          );
+        }),
+      {fastCheck: {numRuns: 50}},
+    );
+
+    it.effect.prop(
       'admits only a capped status inventory and fails closed on raw overflow',
       {
         extraEntries: FC.integer({max: 3, min: 0}),
@@ -652,5 +727,12 @@ function fixtureIdentity(home: string): RepositoryIdentity {
     repoRoot: `${home}/repository`,
     repositoryId: 'b'.repeat(64),
     worktreeId: 'c'.repeat(64),
+  };
+}
+
+function observedFailedStatus(heartbeatAgeMilliseconds: number): ObservedCodeGraphBuildStatus {
+  return {
+    ...fixtureStatus(fixtureIdentity('/tmp'), 'a'.repeat(32), 0, 'failed'),
+    observation: {heartbeatAgeMilliseconds, liveness: 'failed'},
   };
 }

--- a/test/unit/code-graph.cli-progress.test.ts
+++ b/test/unit/code-graph.cli-progress.test.ts
@@ -1,0 +1,88 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  formatCodeGraphIndexProgressLine,
+  formatCodeGraphPurgeProgressLine,
+  formatCodeGraphRepairProgressLine,
+} from '../../src/code_graph/cli_progress.js';
+import type {CodeGraphProgress} from '../../src/code_graph/types.js';
+import {graphMaintenanceRemainingMilliseconds} from '../../src/manager/graph_model.js';
+
+describe('code graph compact CLI progress', () => {
+  it('never includes a scanning activity path or newline', () => {
+    const progress = scanningProgress('src/very/long/path/that/must/stay/out/of/the/status/line.ts');
+    const line = formatCodeGraphIndexProgressLine(progress);
+    expect(line).not.toContain('\n');
+    expect(line).not.toContain('\r');
+    expect(line).not.toContain(progress.activity!.path);
+    expect(line).toContain('Scanning ·');
+  });
+
+  it('formats repair and purge as single compact lines', () => {
+    expect(formatCodeGraphRepairProgressLine({current: 2, phase: 'checking', total: 5})).toBe(
+      'Repairing · checking 2/5 databases',
+    );
+    expect(formatCodeGraphPurgeProgressLine({phase: 'quarantining', dryRun: true})).toBe(
+      'Would purge · quarantining files',
+    );
+  });
+
+  effectIt.effect.prop(
+    'index lines stay one row and omit scanning paths',
+    {
+      path: fc.uuid().map(id => `src/${id}/file.ts`),
+      completed: fc.integer({max: 10_000, min: 0}),
+      total: fc.integer({max: 10_000, min: 0}),
+    },
+    ({path, completed, total}) =>
+      Effect.sync(() => {
+        const line = formatCodeGraphIndexProgressLine(scanningProgress(path, completed, total));
+        expect(line.includes('\n') || line.includes('\r')).toBe(false);
+        expect(line).not.toContain(path);
+      }),
+    {fastCheck: {numRuns: 40}},
+  );
+
+  effectIt.effect.prop(
+    'maintenance remaining estimate is monotone as completed increases',
+    {
+      elapsed: fc.integer({max: 60_000, min: 1}),
+      total: fc.integer({max: 32, min: 2}),
+    },
+    ({elapsed, total}) =>
+      Effect.sync(() => {
+        const startedAt = '2026-09-09T00:00:00.000Z';
+        const now = Date.parse(startedAt) + elapsed;
+        let previous = Number.POSITIVE_INFINITY;
+        for (let completed = 1; completed <= total; completed += 1) {
+          const remaining = graphMaintenanceRemainingMilliseconds({completed, startedAt, total}, now);
+          expect(remaining).toBeDefined();
+          expect(remaining!).toBeLessThanOrEqual(previous);
+          previous = remaining!;
+        }
+      }),
+    {fastCheck: {numRuns: 40}},
+  );
+});
+
+function scanningProgress(path: string, completed = 3, total = 10): Extract<CodeGraphProgress, {phase: 'scanning'}> {
+  return {
+    accepted: 2,
+    activity: {
+      batchCompleted: 1,
+      batchTotal: 2,
+      bytes: 128,
+      language: 'typescript',
+      path,
+      stage: 'extracting',
+    },
+    completed,
+    excluded: 0,
+    phase: 'scanning',
+    skipped: 1,
+    total,
+    unit: 'files',
+  };
+}

--- a/test/unit/code-graph.cli-progress.test.ts
+++ b/test/unit/code-graph.cli-progress.test.ts
@@ -3,6 +3,7 @@ import {Effect} from 'effect';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
+  formatCodeGraphDoctorProgressLine,
   formatCodeGraphIndexProgressLine,
   formatCodeGraphPurgeProgressLine,
   formatCodeGraphRepairProgressLine,
@@ -20,9 +21,12 @@ describe('code graph compact CLI progress', () => {
     expect(line).toContain('Scanning ·');
   });
 
-  it('formats repair and purge as single compact lines', () => {
+  it('formats repair, doctor, and purge as single compact lines', () => {
     expect(formatCodeGraphRepairProgressLine({current: 2, phase: 'checking', total: 5})).toBe(
       'Repairing · checking 2/5 databases',
+    );
+    expect(formatCodeGraphDoctorProgressLine({current: 2, phase: 'checking', total: 5})).toBe(
+      'Checking · checking 2/5 databases',
     );
     expect(formatCodeGraphPurgeProgressLine({phase: 'quarantining', dryRun: true})).toBe(
       'Would purge · quarantining files',

--- a/test/unit/code-graph.inventory.test.ts
+++ b/test/unit/code-graph.inventory.test.ts
@@ -167,6 +167,10 @@ describe('native code graph inventory policy', () => {
 
   it('does not reject eligible source paths based on individual file size', () => {
     expect(acceptsRepositoryPath('src/generated-but-tracked.ts')).toBe(true);
+    expect(acceptsRepositoryPath('src/a.ts', 'src/a.ts')).toBe(false);
+    expect(acceptsRepositoryPath('src/b.ts', '', [], [], 'src/b.ts')).toBe(false);
+    expect(acceptsRepositoryPath('src/c.ts', 'src/a.ts', [], [], 'src/b.ts')).toBe(true);
+    expect(acceptsRepositoryPath('src/a.ts', 'src/a.ts', [], [], '!src/a.ts')).toBe(false);
     expect(shouldOmitRepositoryContent('src/generated-but-tracked.ts', Number.MAX_SAFE_INTEGER)).toBe(false);
     expect(shouldOmitRepositoryContent('recordings/architecture.mp4', CORPUS_EXTRACTION_SOURCE_BYTES_LIMIT + 1)).toBe(
       true,
@@ -281,5 +285,30 @@ describe('native code graph inventory policy', () => {
     });
     expect(JSON.stringify(preview)).not.toContain('src/active.ts');
     expect(JSON.stringify(preview)).not.toContain('package.json');
+  });
+
+  it('unions committed and local Threadnote ignore files in inventory preview', () => {
+    const entries = [
+      {path: 'src/a.ts', size: 10},
+      {path: 'src/b.ts', size: 20},
+      {path: 'src/c.ts', size: 30},
+    ];
+    const groupFiles = (
+      options: {readonly threadnoteIgnore?: string; readonly threadnoteIgnoreLocal?: string},
+      reason: string,
+    ) => summarizeCodeGraphInventoryPreview(entries, options).groups.find(group => group.reason === reason)?.files ?? 0;
+
+    expect(groupFiles({threadnoteIgnore: 'src/a.ts\n'}, 'threadnote-ignore')).toBe(1);
+    expect(groupFiles({threadnoteIgnoreLocal: 'src/b.ts\n'}, 'threadnote-ignore')).toBe(1);
+    expect(groupFiles({threadnoteIgnore: 'src/a.ts\n', threadnoteIgnoreLocal: 'src/b.ts\n'}, 'threadnote-ignore')).toBe(
+      2,
+    );
+    expect(groupFiles({}, 'threadnote-ignore')).toBe(0);
+    expect(
+      summarizeCodeGraphInventoryPreview(entries, {
+        threadnoteIgnore: 'src/a.ts\n',
+        threadnoteIgnoreLocal: 'src/b.ts\n',
+      }).groups.find(group => group.reason === 'admitted' && group.language === 'typescript'),
+    ).toMatchObject({files: 1});
   });
 });

--- a/test/unit/code-graph.maintenance-progress.test.ts
+++ b/test/unit/code-graph.maintenance-progress.test.ts
@@ -1,0 +1,65 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {
+  observeCodeGraphMaintenanceStatus,
+  withCodeGraphReportedMaintenanceIntent,
+} from '../../src/code_graph/maintenance_gate.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {mkdtemp, rm} from '../helpers/effect-filesystem.js';
+
+describe('reported graph-maintenance progress', () => {
+  effectIt.effect('publishes graph-maintenance status without a snapshot id', () =>
+    Effect.gen(function* () {
+      const home = yield* Effect.acquireRelease(
+        Effect.promise(() => mkdtemp('threadnote-graph-maintenance-status-')),
+        directory => Effect.promise(() => rm(directory, {force: true, recursive: true})),
+      );
+      const observed = yield* withCodeGraphReportedMaintenanceIntent(
+        home,
+        {operation: 'graph-maintenance'},
+        {completed: 1, phase: 'verifying-graph', total: 4},
+        reporter =>
+          reporter
+            .progress({completed: 2, phase: 'retiring-and-cleaning', total: 4})
+            .pipe(Effect.andThen(observeCodeGraphMaintenanceStatus(home))),
+      );
+
+      expect(observed).toMatchObject({
+        completed: 2,
+        operation: 'graph-maintenance',
+        phase: 'retiring-and-cleaning',
+        total: 4,
+      });
+      expect(observed?.snapshotId).toBeUndefined();
+      expect(yield* observeCodeGraphMaintenanceStatus(home)).toBeUndefined();
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('publishes a checkout-scoped graph-maintenance meter', () =>
+    Effect.gen(function* () {
+      const home = yield* Effect.acquireRelease(
+        Effect.promise(() => mkdtemp('threadnote-graph-maintenance-checkout-status-')),
+        directory => Effect.promise(() => rm(directory, {force: true, recursive: true})),
+      );
+      const checkoutId = 'a'.repeat(64);
+      const observed = yield* withCodeGraphReportedMaintenanceIntent(
+        home,
+        {checkoutId, operation: 'graph-maintenance'},
+        {completed: 0, phase: 'acquiring-gates', total: 5},
+        () => observeCodeGraphMaintenanceStatus(home),
+      );
+
+      expect(observed).toMatchObject({
+        checkoutId,
+        completed: 0,
+        operation: 'graph-maintenance',
+        phase: 'acquiring-gates',
+        total: 5,
+      });
+      expect(observed?.snapshotId).toBeUndefined();
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+});

--- a/test/unit/code-graph.purge.test.ts
+++ b/test/unit/code-graph.purge.test.ts
@@ -1,10 +1,13 @@
 import {readFile, readlink, rename, rm as nodeRm, symlink} from '../helpers/node-fs-promises.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {it as effectIt} from '@effect/vitest';
 import {Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {codeGraphRepositoryLockPath} from '../../src/code_graph/layout.js';
 import {purgeCodeGraphIndex} from '../../src/code_graph/maintenance.js';
 import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {join, mkdir, mkdtemp, rm, writeFile} from '../helpers/effect-filesystem.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
@@ -49,6 +52,33 @@ describe('targeted code graph purge', () => {
       existed: false,
     });
   });
+
+  effectIt.effect('reports purge safety phases without removing sibling checkouts', () =>
+    Effect.gen(function* () {
+      const home = yield* Effect.promise(() => mkdtemp('threadnote-targeted-graph-purge-progress-'));
+      homes.push(home);
+      const checkoutId = 'd'.repeat(64);
+      const siblingCheckoutId = 'e'.repeat(64);
+      const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+      const siblingRoot = join(home, 'indexes', 'code-graph', 'repositories', siblingCheckoutId);
+      yield* Effect.promise(() => mkdir(join(repositoryRoot, 'vectors'), {recursive: true}));
+      yield* Effect.promise(() => mkdir(siblingRoot, {recursive: true}));
+      yield* Effect.promise(() => writeFile(join(repositoryRoot, 'graph-v3.sqlite'), 'disposable graph\n'));
+      yield* Effect.promise(() => writeFile(join(siblingRoot, 'graph-v3.sqlite'), 'sibling must survive\n'));
+      const phases: string[] = [];
+      const summary = yield* purgeCodeGraphIndex(home, checkoutId, {
+        dryRun: false,
+        onProgress: progress => Effect.sync(() => void phases.push(progress.phase)),
+      });
+
+      expect(summary).toEqual({checkoutId, dryRun: false, existed: true});
+      expect(phases).toEqual(['waiting-builders', 'verifying', 'quarantining', 'deleting', 'deleting']);
+      expect(yield* Effect.promise(() => Bun.file(join(repositoryRoot, 'graph-v3.sqlite')).exists())).toBe(false);
+      expect(yield* Effect.promise(() => readFile(join(siblingRoot, 'graph-v3.sqlite'), 'utf8'))).toContain(
+        'must survive',
+      );
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
 
   it('rejects invalid checkout identities before inspecting storage', async () => {
     const home = await mkdtemp('threadnote-targeted-graph-purge-invalid-');

--- a/test/unit/code-graph.routine-maintenance.test.ts
+++ b/test/unit/code-graph.routine-maintenance.test.ts
@@ -13,6 +13,7 @@ import {
   type CodeGraphRoutineMaintenanceTick,
 } from '../../src/code_graph/maintenance_coordinator.js';
 import {
+  CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE,
   codeGraphRoutineFileBlobCleanupPageStatement,
   codeGraphRoutineMaterializedShardCleanupPageStatement,
   CodeGraphStore,
@@ -197,7 +198,11 @@ describe('routine code graph maintenance', () => {
 
   it('reclaims parser blobs before materialized shards in bounded pages and preserves live cache rows', async () => {
     const fixture = await routineFixture('threadnote-routine-cache-page-');
-    seedRoutineCacheRows(fixture.databasePath, 101, 101);
+    seedRoutineCacheRows(
+      fixture.databasePath,
+      CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE + 1,
+      CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE + 1,
+    );
 
     const results = await runEffect(
       Effect.gen(function* () {
@@ -207,9 +212,17 @@ describe('routine code graph maintenance', () => {
       }),
     );
 
-    expect(results[0]).toMatchObject({cleanup: 'file-blob-cache', remaining: true, rowsDeleted: 100});
+    expect(results[0]).toMatchObject({
+      cleanup: 'file-blob-cache',
+      remaining: true,
+      rowsDeleted: CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE,
+    });
     expect(results[1]).toMatchObject({cleanup: 'file-blob-cache', remaining: true, rowsDeleted: 1});
-    expect(results[2]).toMatchObject({cleanup: 'materialized-shard-cache', remaining: true, rowsDeleted: 100});
+    expect(results[2]).toMatchObject({
+      cleanup: 'materialized-shard-cache',
+      remaining: true,
+      rowsDeleted: CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE,
+    });
     expect(results[3]).toMatchObject({cleanup: 'materialized-shard-cache', remaining: false, rowsDeleted: 1});
     expect(results[4]).toMatchObject({cleanup: 'none', remaining: true, rowsDeleted: 0});
     expect(results[5]).toEqual(noWorkResult);
@@ -268,8 +281,8 @@ describe('routine code graph maintenance', () => {
     fc.assert(
       fc.property(
         fc.record({
-          fileBlobs: fc.integer({max: 205, min: 0}),
-          materializedShards: fc.integer({max: 205, min: 0}),
+          fileBlobs: fc.integer({max: CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE + 50, min: 0}),
+          materializedShards: fc.integer({max: CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE + 50, min: 0}),
           reverseInsertion: fc.boolean(),
         }),
         ({fileBlobs, materializedShards, reverseInsertion}) => {
@@ -302,12 +315,18 @@ describe('routine code graph maintenance', () => {
               materializedCursor = candidates.at(-1)!;
             }
 
-            expect(examinedPages.every(rows => rows > 0 && rows <= 100)).toBe(true);
-            expect(pages.every(page => page.rows > 0 && page.rows <= 100)).toBe(true);
+            expect(examinedPages.every(rows => rows > 0 && rows <= CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE)).toBe(true);
+            expect(pages.every(page => page.rows > 0 && page.rows <= CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE)).toBe(true);
             expect(pages.reduce((total, page) => total + page.rows, 0)).toBe(fileBlobs + materializedShards);
             expect(pages.map(page => page.cleanup)).toEqual([
-              ...Array.from({length: Math.ceil(fileBlobs / 100)}, () => 'file-blob-cache' as const),
-              ...Array.from({length: Math.ceil(materializedShards / 100)}, () => 'materialized-shard-cache' as const),
+              ...Array.from(
+                {length: Math.ceil(fileBlobs / CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE)},
+                () => 'file-blob-cache' as const,
+              ),
+              ...Array.from(
+                {length: Math.ceil(materializedShards / CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE)},
+                () => 'materialized-shard-cache' as const,
+              ),
             ]);
             expect(readRoutineCacheDatabaseCounts(database)).toEqual({fileBlobs: 1, materializedShards: 1});
           } finally {
@@ -1817,7 +1836,7 @@ function readRoutineFileBlobCacheCandidates(
       cursor?.contentHash ?? null,
       cursor?.extractorSet ?? null,
       cursor?.path ?? null,
-      100,
+      CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE,
     );
   return rows.map(row => ({contentHash: row.content_hash, extractorSet: row.extractor_set, path: row.path_hint}));
 }
@@ -1831,7 +1850,7 @@ function readRoutineMaterializedShardCacheCandidates(database: Database, cursor:
        ORDER BY id
        LIMIT ?`,
     )
-    .all(cursor ?? null, cursor ?? null, 100)
+    .all(cursor ?? null, cursor ?? null, CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE)
     .map(row => row.id);
 }
 

--- a/test/unit/code-graph.threadnote-ignore.test.ts
+++ b/test/unit/code-graph.threadnote-ignore.test.ts
@@ -36,15 +36,15 @@ describe('threadnote ignore union', () => {
   effectIt.effect.prop(
     'union ignore matches committed or local independently',
     {
-      committed: fc.constantFrom('', 'src/a.ts', 'tmp/', 'vendor/**'),
-      local: fc.constantFrom('', 'src/b.ts', 'tmp/', 'scratch.ts'),
+      committed: fc.constantFrom('', 'src/a.ts', 'tmp/', 'vendor/**', '!src/c.ts'),
+      local: fc.constantFrom('', 'src/b.ts', 'tmp/', 'scratch.ts', '!src/a.ts'),
       path: fc.constantFrom('src/a.ts', 'src/b.ts', 'src/c.ts', 'tmp/x.ts', 'vendor/lib.ts', 'scratch.ts'),
     },
     ({committed, local, path}) =>
       Effect.sync(() => {
         expect(isIgnoredByThreadnote(path, compileThreadnoteIgnore(committed, local))).toBe(
-          isIgnoredByThreadnote(path, compileThreadnoteIgnore(committed)) ||
-            isIgnoredByThreadnote(path, compileThreadnoteIgnore(local)),
+          isIgnoredByThreadnote(path, compileThreadnoteIgnore(committed, '')) ||
+            isIgnoredByThreadnote(path, compileThreadnoteIgnore('', local)),
         );
       }),
     {fastCheck: {numRuns: 40}},

--- a/test/unit/code-graph.threadnote-ignore.test.ts
+++ b/test/unit/code-graph.threadnote-ignore.test.ts
@@ -1,0 +1,52 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  compileThreadnoteIgnore,
+  isIgnoredByThreadnote,
+  isOverlayAdmissionControlPath,
+  THREADNOTE_IGNORE_FILE,
+  THREADNOTE_IGNORE_LOCAL_FILE,
+} from '../../src/code_graph/threadnote_ignore.js';
+
+describe('threadnote ignore union', () => {
+  it('ignores A-only, B-only, both, and neither independently', () => {
+    const committed = 'src/a.ts\n';
+    const local = 'src/b.ts\n';
+    expect(isIgnoredByThreadnote('src/a.ts', compileThreadnoteIgnore(committed, ''))).toBe(true);
+    expect(isIgnoredByThreadnote('src/b.ts', compileThreadnoteIgnore(committed, ''))).toBe(false);
+    expect(isIgnoredByThreadnote('src/a.ts', compileThreadnoteIgnore('', local))).toBe(false);
+    expect(isIgnoredByThreadnote('src/b.ts', compileThreadnoteIgnore('', local))).toBe(true);
+    expect(isIgnoredByThreadnote('src/a.ts', compileThreadnoteIgnore(committed, local))).toBe(true);
+    expect(isIgnoredByThreadnote('src/b.ts', compileThreadnoteIgnore(committed, local))).toBe(true);
+    expect(isIgnoredByThreadnote('src/c.ts', compileThreadnoteIgnore(committed, local))).toBe(false);
+  });
+
+  it('does not let a local negation un-ignore a committed ignore', () => {
+    expect(isIgnoredByThreadnote('src/a.ts', compileThreadnoteIgnore('src/a.ts\n', '!src/a.ts\n'))).toBe(true);
+  });
+
+  it('treats both ignore files as overlay admission controls', () => {
+    expect(isOverlayAdmissionControlPath(THREADNOTE_IGNORE_FILE)).toBe(true);
+    expect(isOverlayAdmissionControlPath(THREADNOTE_IGNORE_LOCAL_FILE)).toBe(true);
+    expect(isOverlayAdmissionControlPath('.gitignore')).toBe(true);
+  });
+
+  effectIt.effect.prop(
+    'union ignore matches committed or local independently',
+    {
+      committed: fc.constantFrom('', 'src/a.ts', 'tmp/', 'vendor/**'),
+      local: fc.constantFrom('', 'src/b.ts', 'tmp/', 'scratch.ts'),
+      path: fc.constantFrom('src/a.ts', 'src/b.ts', 'src/c.ts', 'tmp/x.ts', 'vendor/lib.ts', 'scratch.ts'),
+    },
+    ({committed, local, path}) =>
+      Effect.sync(() => {
+        expect(isIgnoredByThreadnote(path, compileThreadnoteIgnore(committed, local))).toBe(
+          isIgnoredByThreadnote(path, compileThreadnoteIgnore(committed)) ||
+            isIgnoredByThreadnote(path, compileThreadnoteIgnore(local)),
+        );
+      }),
+    {fastCheck: {numRuns: 40}},
+  );
+});

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -1,6 +1,7 @@
 import {createElement} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, it} from 'vitest';
+import {CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS} from '../../src/code_graph/build_status_validation.js';
 import {
   cacheGraphNodeDetail,
   createGraphQueryRequestGate,
@@ -680,6 +681,32 @@ describe('manager graph focus', () => {
     };
     expect(graphBuildIsActive(staleOwner)).toBe(true);
     expect(graphBuildShouldDisplay(staleOwner)).toBe(true);
+    const recentFailed = graphBuildStatus('failed');
+    expect(graphBuildShouldDisplay(recentFailed)).toBe(true);
+    expect(
+      graphBuildShouldDisplay({
+        ...recentFailed,
+        observation: {
+          heartbeatAgeMilliseconds: CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS,
+          liveness: 'failed',
+        },
+      }),
+    ).toBe(true);
+    expect(
+      graphBuildShouldDisplay({
+        ...recentFailed,
+        observation: {
+          heartbeatAgeMilliseconds: CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS + 1,
+          liveness: 'failed',
+        },
+      }),
+    ).toBe(false);
+    expect(
+      graphBuildShouldDisplay({
+        ...recentFailed,
+        observation: {heartbeatAgeMilliseconds: Number.POSITIVE_INFINITY, liveness: 'failed'},
+      }),
+    ).toBe(false);
   });
 
   it('shows live reclaiming status when the full graph catalog is not available yet', () => {
@@ -784,6 +811,14 @@ describe('manager graph focus', () => {
       {...graphBuildStatus('completed'), buildId: 'completed'},
       {...graphBuildStatus('running'), buildId: 'running'},
       {...graphBuildStatus('failed'), buildId: 'failed'},
+      {
+        ...graphBuildStatus('failed'),
+        buildId: 'expired-failed',
+        observation: {
+          heartbeatAgeMilliseconds: CODE_GRAPH_FAILED_BUILD_STATUS_RETENTION_MILLISECONDS + 1,
+          liveness: 'failed' as const,
+        },
+      },
     ];
     const waiters = Array.from({length: 5}, (_, index) => ({
       ...graphBuildStatus('queued'),
@@ -795,6 +830,7 @@ describe('manager graph focus', () => {
     expect(selected.total).toBe(7);
     expect(selected.hiddenCount).toBe(3);
     expect(selected.jobs.map(job => job.state)).not.toContain('completed');
+    expect(selected.jobs.map(job => job.buildId)).not.toContain('expired-failed');
     expect(selected.jobs[0]?.buildId).toBe('running');
 
     const neverResolves = () => new Promise<never>(() => undefined);

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -24,6 +24,7 @@ import {
   graphDisplayEdges,
   graphFocusLayoutTargets,
   graphFocusTarget,
+  graphMaintenanceRemainingMilliseconds,
   graphMaintenanceStatusLabel,
   graphNodeDetailRequestIsCurrent,
   graphNodeSizeValues,
@@ -668,6 +669,25 @@ describe('manager graph focus', () => {
     };
     expect(graphStatusPollDelay([], maintenance)).toBe(1_000);
     expect(graphMaintenanceStatusLabel(maintenance)).toBe('Selected snapshot purge · rechecking graph safety evidence');
+    expect(
+      graphMaintenanceStatusLabel({
+        completed: 2,
+        operation: 'graph-maintenance',
+        phase: 'verifying-graph',
+        startedAt: '2026-09-09T00:00:00.000Z',
+        total: 4,
+      }),
+    ).toBe('Graph maintenance · verifying graph store');
+    expect(
+      graphMaintenanceRemainingMilliseconds(
+        {
+          completed: 2,
+          startedAt: '2026-09-09T00:00:00.000Z',
+          total: 4,
+        },
+        Date.parse('2026-09-09T00:00:10.000Z'),
+      ),
+    ).toBe(10_000);
     const abandoned = {
       ...graphBuildStatus('running'),
       observation: {heartbeatAgeMilliseconds: 60_000, liveness: 'abandoned' as const},


### PR DESCRIPTION
## Summary
- Failed graph-build cards in Manager expire after one hour instead of staying on the dashboard indefinitely.
- `threadnote graph index`, `repair`, `purge`, and `compact` rewrite one TTY status line with phase, counts, and ETA when available; `--json` output is unchanged.
- Manager graph maintenance shows phase progress and ETA when completed/total is available, including home-wide purge.
- `.threadnoteignore.local` is an uncommitted additive union with committed `.threadnoteignore`. A local `!` rule cannot un-ignore a committed exclude.
- Residual graph maintenance drains faster (larger cache cleanup pages and a longer automatic tail) without changing safety locks.
- `threadnote repair` prints the summary and doctor after the spinner stops; doctor uses `Checking · …` for the native graph check.

## Test plan
- [ ] Focused unit tests passed locally (9 files, 144 tests): `cli-ui.progress`, `code-graph.cli-progress`, `code-graph.threadnote-ignore`, `code-graph.build-status-bounded`, `code-graph.maintenance-progress`, `code-graph.purge`, `manager-graph`, `code-graph.routine-maintenance`, `lifecycle.safety`.
- [ ] Focused integration: `test/integration/code-graph.lifecycle.test.ts` `-t "keeps default lifecycle repair bounded"` passed (doctor uses `Checking ·`, summary then doctor after spinner).
- [ ] Pre-commit lint, prettier, and typecheck passed on the review-loop and release-prepare commits.
- [ ] `bun run release:prepare -- --patch --dry-run --json` reported `4.6.9`; applied with `--version 4.6.9`.
- [ ] Global exact-HEAD install: `threadnote v4.6.9-local.ge83de90d5cfc38f0740e59850c0241b495a80ed4`; `threadnote graph --help` lists index/repair/purge/compact.
- [ ] CI full suite green (do not run the complete suite locally).
- [ ] After merge onto protected main, tag `v4.6.9` on that exact commit and push the tag. Do not tag from this PR.