### PR TITLE
docs: explain how to enable optional memory enrichment

### DIFF
--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1118,6 +1118,22 @@ The body remains ordinary **Markdown**.
     expect(searchDocs(index, 'context brief')[0]?.article.id).toBe('worksets');
     expect(searchDocs(index, 'share memory team')[0]?.article.id).toBe('publish-memory');
     expect(searchDocs(index, 'architecture analysis')[0]?.article.id).toBe('graph-analysis');
+    expect(searchDocs(index, 'memory enrichment generation model')[0]?.article.id).toBe('local-ai');
+  });
+
+  it('documents how to enable optional memory enrichment on the Local AI page', () => {
+    const localAi = docsSections.flatMap(section => section.articles).find(article => article.id === 'local-ai');
+    const content = JSON.stringify(localAi);
+
+    expect(localAi).toBeDefined();
+    expect(content).toContain('Memory enrichment');
+    expect(content).toContain('A download alone does not enable enrichment.');
+    expect(content).toContain('threadnote models install <model-id>');
+    expect(content).toContain('threadnote models select generation <model-id>');
+    expect(content).toContain('threadnote enrich-memories --apply');
+    expect(content).toContain('threadnote enrich-memories --apply --install-local-ai');
+    expect(content).toContain('new remember and MCP store writes try enrichment automatically');
+    expect(content).not.toContain('gemma-4-e4b-it-q4');
   });
 
   it('documents the complete bounded cross-repository graph-query workflow', () => {

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -12,6 +12,7 @@ import {
 } from './docsMemoryCitationReference.js';
 import {memoryWorkflowsDocsSection} from './docsMemoryWorkflows.js';
 import {optionalImageProjectionCliCommand, optionalImageProjectionDocsArticle} from './docsImageProjection.js';
+import {localAiDocsArticle} from './docsLocalAi.js';
 import {optionalAnonymousTelemetryCliCommand, optionalAnonymousTelemetryDocsArticle} from './docsTelemetry.js';
 import type {CliCommandReference, DocsSection, McpToolReference} from './docsTypes.js';
 export type {
@@ -793,33 +794,7 @@ threadnote recall --query "checkout retry contract" --threshold 0.3 --caller-cwd
           },
         ],
       },
-      {
-        id: 'local-ai',
-        title: 'Local AI',
-        summary: 'A core BGE embedding model runs locally through a supervised node-llama-cpp worker.',
-        body: [
-          {
-            type: 'paragraph',
-            text: 'Install and repair automatically extract, verify, select, and preserve the pinned 36.7 MB BGE Small embedding model bundled in the standalone executable. Model manifests pin revision, filename, byte size, SHA-256, license, runtime compatibility, and memory class before atomic promotion.',
-          },
-          {
-            type: 'paragraph',
-            text: 'The parent CLI, MCP, or Manager process lazily starts one supervised local-model child from the same standalone executable. The worker keeps model sessions warm and isolates native-addon crashes from the long-lived parent. Threadnote requests prebuilt node-llama-cpp binaries only and never silently compiles llama.cpp.',
-          },
-          {
-            type: 'code',
-            language: 'sh',
-            code: `threadnote models list
-threadnote models runtime
-threadnote models verify bge-small-en-v1.5-q8
-threadnote index status`,
-          },
-          {
-            type: 'note',
-            text: 'Embedding is core functionality. Reranking and structured generation are optional roles and are not silently selected; the measured Jina reranker failed the frozen no-answer gate.',
-          },
-        ],
-      },
+      localAiDocsArticle,
       {
         id: 'memory-vs-code',
         title: 'Memory vs current code',

--- a/website/src/content/docsLocalAi.ts
+++ b/website/src/content/docsLocalAi.ts
@@ -1,0 +1,77 @@
+import type {DocsArticle} from './docsTypes.js';
+
+export const localAiDocsArticle: DocsArticle = {
+  id: 'local-ai',
+  title: 'Local AI',
+  summary:
+    'Core local embeddings plus an optional generation model that writes retrieval keywords for memory enrichment.',
+  keywords: [
+    'memory enrichment',
+    'enrich-memories',
+    'generation model',
+    'retrieval keywords',
+    'local generation',
+    'models select generation',
+  ],
+  body: [
+    {
+      type: 'paragraph',
+      text: 'Install and repair automatically extract, verify, select, and preserve the pinned 36.7 MB BGE Small embedding model bundled in the standalone executable. Model manifests pin revision, filename, byte size, SHA-256, license, runtime compatibility, and memory class before atomic promotion.',
+    },
+    {
+      type: 'paragraph',
+      text: 'The parent CLI, MCP, or Manager process lazily starts one supervised local-model child from the same standalone executable. The worker keeps model sessions warm and isolates native-addon crashes from the long-lived parent. Threadnote requests prebuilt node-llama-cpp binaries only and never silently compiles llama.cpp.',
+    },
+    {
+      type: 'code',
+      language: 'sh',
+      code: `threadnote models list
+threadnote models runtime
+threadnote models verify bge-small-en-v1.5-q8
+threadnote index status`,
+    },
+    {
+      type: 'note',
+      text: 'Embedding is core functionality. Reranking and structured generation are optional roles and are not silently selected; the measured Jina reranker failed the frozen no-answer gate.',
+    },
+    {
+      type: 'heading',
+      text: 'Memory enrichment',
+    },
+    {
+      type: 'paragraph',
+      text: 'Semantic recall uses the core embedding model. Memory enrichment is a separate, optional step: a selected local generation model proposes retrieval keywords that Threadnote stores on the memory. Those keywords participate in later lexical ranking. Recall still works without them.',
+    },
+    {
+      type: 'heading',
+      text: 'Enable enrichment',
+    },
+    {
+      type: 'paragraph',
+      text: 'Install a catalog model whose role is generation, then select it for that role. A download alone does not enable enrichment.',
+    },
+    {
+      type: 'code',
+      language: 'sh',
+      code: `threadnote models list
+threadnote models install <model-id>
+threadnote models select generation <model-id>`,
+    },
+    {
+      type: 'paragraph',
+      text: 'After a generation model is selected, new remember and MCP store writes try enrichment automatically. If the local worker cannot run, Threadnote still stores the memory and prints a skip warning. Backfill existing memories with enrich-memories; preview first, then apply.',
+    },
+    {
+      type: 'code',
+      language: 'sh',
+      code: `threadnote enrich-memories
+threadnote enrich-memories --apply
+# Install and select the pinned catalog generation model when none is selected:
+threadnote enrich-memories --apply --install-local-ai`,
+    },
+    {
+      type: 'note',
+      text: 'enrich-memories skips smoke records and memories with pending code anchors. --force regenerates keywords. Shared memories are written locally; run threadnote share sync to publish them. threadnote local-ai remains a deprecated compatibility alias for the models surface.',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Document optional memory enrichment on the Local AI page: what it does, that a generation-model download alone does not enable it, and the `threadnote models install` / `models select generation` plus `enrich-memories --apply` flow.
- Extract the Local AI article so `website/src/content/docs.ts` stays under the 2000-line production limit.
- Lock the enablement copy and docs-search ranking with website-content tests.

## Test plan
- [x] Focused `website-content` tests for Local AI copy and search ranking
- [x] Local docs page at `/docs/local-ai/` shows Memory enrichment / Enable enrichment and search ranks Local AI first for "memory enrichment"
- [ ] CI website/content checks pass