### PR TITLE
Keep process inventory, recall pointers, and deferred anchors honest at runtime

### DIFF
--- a/.github/release-notes/v4.6.10.md
+++ b/.github/release-notes/v4.6.10.md
@@ -1,0 +1,15 @@
+## What's new
+
+Threadnote 4.6.10 finishes deferred code-anchor recovery after graph publication, keeps macOS process inventory from dropping live MCP sessions, and hides recall pointers that can no longer be read.
+
+### Deferred code-anchor recovery
+
+Pending private code links finalize when that checkout's graph publishes in the same process. If the original worktree is missing or unusable, Threadnote discards the pending link instead of attaching it to another checkout or to main. Still-present unresolved locators keep the subset that exists on the current graph; a memory write stays all-or-nothing.
+
+### Live MCP sessions on macOS
+
+Process inventory uses a locale-stable identity, and keep-alive matching is loose both ways between the older and newer Darwin identity forms. A Cursor MCP session and Manager that disagree on locale or timezone no longer garbage-collect a live MCP row. Terminate and signal checks stay strict.
+
+### Honest recall pointers
+
+Recall omits memory URIs that are indexed but missing or unreadable. Batch `read_context` returns the memories that succeed and lists the missing URIs, instead of failing the whole request.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.9",
+  "version": "4.6.10",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -2,7 +2,7 @@ import {Clock, Console, Crypto, Effect, FileSystem, Option, Path, Schema} from '
 import {startProgress, withProgressLine} from '../cli_ui.js';
 import {writeFinalCliOutput} from '../effect/cli_output.js';
 import {SystemInfo} from '../effect/system.js';
-import {healAnchorsAfterGraphIndex, healAnchorsAfterWorksetPrepare} from '../memory/deferred_code_anchor_recovery.js';
+import {healAnchorsAfterWorksetPrepare} from '../memory/deferred_code_anchor_recovery.js';
 import type {RuntimeConfig} from '../types.js';
 import {CodeGraphIndexer} from './indexer.js';
 import {
@@ -750,7 +750,6 @@ export const runCodeGraphIndex = Effect.fn('codeGraph.command.index')(function* 
       onProgress: reportProgress,
       threadnoteHome: config.agentContextHome,
     });
-    yield* healAnchorsAfterGraphIndex(config, cwd, summary.identity);
     yield* writeFinalCliOutput(JSON.stringify({type: 'code-graph-index', version: 1, ...summary}));
     return;
   }
@@ -775,7 +774,6 @@ export const runCodeGraphIndex = Effect.fn('codeGraph.command.index')(function* 
         ),
       ),
   );
-  yield* healAnchorsAfterGraphIndex(config, cwd, summary.identity);
   yield* Console.log(
     `Code graph ready for ${summary.identity.displayName}: ${summary.snapshot.fileCount} file(s), ` +
       `${summary.snapshot.symbolCount} symbol(s), ${summary.snapshot.edgeCount} relationship(s); ` +

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -774,9 +774,10 @@ export const makeCodeGraphWatcher = Effect.fn('codeGraph.makeWatcher')(function*
     refresh: options =>
       Effect.gen(function* () {
         yield* touchWatch(options.key);
-        return yield* scheduleRefresh({...options, admissionClass: 'current-required'}, false).pipe(
-          Effect.map(decision => decision.start),
-        );
+        return yield* scheduleRefresh(
+          {...options, admissionClass: options.admissionClass ?? 'current-required'},
+          false,
+        ).pipe(Effect.map(decision => decision.start));
       }),
     status: key =>
       Effect.gen(function* () {
@@ -1057,12 +1058,14 @@ const indexRepository = (indexer: CodeGraphIndexerShape, options: CodeGraphWatch
 
 /** Watcher-driven refresh never owns embedding; explicit `graph index` still does. */
 export function codeGraphWatcherRefreshIndexRequest(options: CodeGraphWatchOptions): {
+  readonly admissionClass?: CodeGraphBuilderAdmissionClass;
   readonly cwd: string;
   readonly ensureVectors: false;
   readonly onProgress: CodeGraphWatchOptions['onProgress'];
   readonly threadnoteHome: string;
 } {
   return {
+    ...(options.admissionClass === undefined ? {} : {admissionClass: options.admissionClass}),
     cwd: options.cwd,
     ensureVectors: false,
     onProgress: options.onProgress,

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -21,6 +21,11 @@ import {CodeGraphLanguagePackRegistry} from '../code_graph/languages/registry.js
 import {TreeSitterRuntime} from '../code_graph/tree_sitter/runtime.js';
 import {CodeGraphAnalysis} from '../code_graph/analysis.js';
 import {CodeGraphParserPool} from '../code_graph/parser_worker.js';
+import {
+  healAfterPublishedGraphIndex,
+  withDeferredCodeAnchorIndexHeal,
+} from '../memory/deferred_code_anchor_index_heal.js';
+import {deferredCodeAnchorRefreshSchedulerLayer} from '../memory/deferred_code_anchor_refresh.js';
 import {resolveTelemetryConfiguration} from '../telemetry/config.js';
 import {
   resolveAgentSession,
@@ -61,19 +66,29 @@ const codeGraphLanguagePackLayer = CodeGraphLanguagePackRegistry.layer;
 const codeGraphEmbeddingLayer = CodeGraphEmbeddingIndex.layer.pipe(
   Layer.provideMerge(Layer.mergeAll(localModelCatalogLayer, localModelRuntimeLayer, localModelStoreLayer)),
 );
-const codeGraphIndexerLayer = CodeGraphIndexer.layer.pipe(
-  Layer.provideMerge(
-    Layer.mergeAll(
-      codeGraphStoreLayer,
-      codeGraphMaintenanceCoordinatorLayer,
-      codeGraphEmbeddingLayer,
-      codeGraphLanguagePackLayer,
-      codeGraphParserPoolLayer,
-      commandLayer,
-      systemLayer,
-      treeSitterRuntimeLayer,
-    ),
-  ),
+const codeGraphIndexerDependencies = Layer.mergeAll(
+  codeGraphStoreLayer,
+  codeGraphMaintenanceCoordinatorLayer,
+  codeGraphEmbeddingLayer,
+  codeGraphLanguagePackLayer,
+  codeGraphParserPoolLayer,
+  commandLayer,
+  systemLayer,
+  treeSitterRuntimeLayer,
+);
+const codeGraphIndexerLayer = Layer.effect(
+  CodeGraphIndexer,
+  Effect.gen(function* () {
+    const inner = yield* CodeGraphIndexer;
+    return CodeGraphIndexer.of(
+      withDeferredCodeAnchorIndexHeal(inner, (options, summary) =>
+        healAfterPublishedGraphIndex(options.threadnoteHome, options.cwd, summary.identity),
+      ),
+    );
+  }),
+).pipe(
+  Layer.provide(CodeGraphIndexer.layer.pipe(Layer.provideMerge(codeGraphIndexerDependencies))),
+  Layer.provideMerge(codeGraphIndexerDependencies),
 );
 const codeGraphQueryLayer = CodeGraphQueryService.layer.pipe(Layer.provideMerge(codeGraphIndexerLayer));
 // MCP hosts detect themselves inside CodeGraphWatcher and spawn CLI `graph index`
@@ -104,7 +119,7 @@ export const ApplicationLayer = ApplicationServicesLayer.pipe(
  */
 export function applicationLayerForHome(home: string, entrypoint: 'cli' | 'mcp') {
   return telemetryLayerForHome(home, entrypoint === 'cli' ? 'invocation' : 'broker').pipe(
-    Layer.provideMerge(ApplicationLayer),
+    Layer.provideMerge(deferredCodeAnchorRefreshSchedulerLayer.pipe(Layer.provideMerge(ApplicationLayer))),
   );
 }
 

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -21,6 +21,7 @@ import {SystemInfo} from '../../effect/system.js';
 import {captureConsole} from '../../effect/console.js';
 import {monitorSharedRepositories} from '../../effect/share.js';
 import {monitorGraphShareContributions} from '../../code_graph/sharing/contribution_retry.js';
+import {refreshPendingDeferredCodeAnchorWorkspaces} from '../../memory/deferred_code_anchor_refresh.js';
 import {runObsidianProjectionPublish} from '../../obsidian/projection.js';
 import {withProductionLogging} from '../../effect/production_log.js';
 import {withAnonymousTelemetry} from '../../effect/telemetry.js';
@@ -136,6 +137,9 @@ export const mcpServerEffect = withAnonymousTelemetry(
         }
         if (mcpToolCapabilities(toolset).graphLocal) {
           yield* Effect.forkScoped(monitorGraphShareContributions(config.agentContextHome));
+        }
+        if (mcpToolCapabilities(toolset).memoryRead && mcpToolCapabilities(toolset).graphLocal) {
+          yield* Effect.forkScoped(refreshPendingDeferredCodeAnchorWorkspaces(config));
         }
         yield* Console.error('Threadnote local MCP adapter running');
         return yield* server.run();

--- a/src/mcp/server/memory.ts
+++ b/src/mcp/server/memory.ts
@@ -1296,18 +1296,31 @@ export function runNativeReadTool(
       /** Compatibility field retained for canonical-read v1 consumers. */
       readonly uri: string;
     }> = [];
+    const missing: string[] = [];
+    let firstFailure: unknown;
     for (const input of resolvedInputs) {
-      const uri = input.canonicalUri;
-      const resolved =
-        options.followRelocations !== false && isMemoryRelocationUri(config, uri)
-          ? yield* readMemoryWithRelocations(config, uri)
-          : {
-              canonicalUri: parseResourceId(uri).canonicalUri,
-              content: yield* store.read(resourceStoreLocation(config), uri),
-              relocationDepth: 0,
-              requestedUri: parseResourceId(uri).canonicalUri,
-            };
-      yield* verifyResolvedMemoryIdentity(input, resolved.canonicalUri, resolved.content);
+      const outcome = yield* Effect.result(
+        Effect.gen(function* () {
+          const uri = input.canonicalUri;
+          const resolved =
+            options.followRelocations !== false && isMemoryRelocationUri(config, uri)
+              ? yield* readMemoryWithRelocations(config, uri)
+              : {
+                  canonicalUri: parseResourceId(uri).canonicalUri,
+                  content: yield* store.read(resourceStoreLocation(config), uri),
+                  relocationDepth: 0,
+                  requestedUri: parseResourceId(uri).canonicalUri,
+                };
+          yield* verifyResolvedMemoryIdentity(input, resolved.canonicalUri, resolved.content);
+          return resolved;
+        }),
+      );
+      if (Result.isFailure(outcome)) {
+        firstFailure ??= outcome.failure;
+        missing.push(input.requestedUri);
+        continue;
+      }
+      const resolved = outcome.success;
       resources.push({
         canonicalUri: resolved.canonicalUri,
         contentIndex: content.length,
@@ -1317,9 +1330,17 @@ export function runNativeReadTool(
       });
       content.push({text: resolved.content, type: 'text'});
     }
+    if (content.length === 0) {
+      return memoryReadErrorResult(config, firstFailure);
+    }
     const result: CallToolResult = {
       _meta: {
-        'threadnote.io/canonical-read': {resources, type: 'threadnote-canonical-read', version: 1},
+        'threadnote.io/canonical-read': {
+          resources,
+          type: 'threadnote-canonical-read',
+          version: 1,
+          ...(missing.length > 0 ? {missing} : {}),
+        },
       },
       content,
     };

--- a/src/mcp/server/recall.ts
+++ b/src/mcp/server/recall.ts
@@ -74,6 +74,7 @@ import {
   type CursorCloudMemoryScope,
 } from '../../cursor/cloud.js';
 import {memoryIdFromIdentityAlias} from '../../memory/identity_alias.js';
+import {memoryReadRecoveryForRequestedUri, memoryReadRecoveryText} from '../../memory/read_recovery.js';
 import {RECALL_RANKER_VERSION} from '../../recall/rank.js';
 import {
   parseRecallMemoryConnectionInput,
@@ -1279,6 +1280,12 @@ export function registerReadTool(
         ].filter((part): part is string => part !== undefined);
         const resources = memoryReadResourcesFromNativeResult(result, requestedUris);
         if (!resources) return argumentError(`${name} could not project the canonical read response.`);
+        const missing = canonicalReadMissing(result);
+        const missingWarnings = missing.map(uri => `Missing memory: ${uri}`);
+        const missingRecoveries = missing.flatMap(uri => {
+          const recovery = memoryReadRecoveryForRequestedUri(uri);
+          return recovery === undefined ? [] : [memoryReadRecoveryText(recovery)];
+        });
         const canonicalRead = canonicalReadMetadata(result);
         const relocatedOutsideScope = memoryScope
           ? canonicalRead?.resources.find(resource => !cursorCloudUriWithinScope(memoryScope, resource.canonicalUri))
@@ -1291,7 +1298,7 @@ export function registerReadTool(
             mode,
             section,
             toolName: name,
-            warnings: syncMessages,
+            warnings: [...syncMessages, ...missingWarnings],
           }),
         );
         if (Result.isFailure(projected)) {
@@ -1322,6 +1329,7 @@ export function registerReadTool(
           content: [
             {type: 'text' as const, text: read.content},
             ...(read.receipt === undefined ? [] : [{type: 'text' as const, text: read.receipt}]),
+            ...missingRecoveries.map(text => ({type: 'text' as const, text})),
           ],
           structuredContent: read.structuredContent,
         };
@@ -1330,18 +1338,32 @@ export function registerReadTool(
   );
 }
 
-function memoryReadResourcesFromNativeResult(
+export function memoryReadResourcesFromNativeResult(
   result: CallToolResult,
   uris: readonly string[],
 ): MemoryReadResource[] | undefined {
   const canonicalRead = canonicalReadMetadata(result);
+  const mappings = canonicalRead?.resources;
+  if (mappings) {
+    return projectCanonicalReadResources(result, mappings);
+  }
+  if (result.content.length !== uris.length) return undefined;
+  return projectCanonicalReadResources(
+    result,
+    uris.map((uri, index) => ({canonicalUri: uri, contentIndex: index, requestedUri: uri})),
+  );
+}
+
+function projectCanonicalReadResources(
+  result: CallToolResult,
+  mappings: readonly {readonly canonicalUri: string; readonly contentIndex: number; readonly requestedUri: string}[],
+): MemoryReadResource[] | undefined {
   const resources: MemoryReadResource[] = [];
-  for (const [index, uri] of uris.entries()) {
-    const mapping = canonicalRead?.resources[index];
-    const content = result.content[mapping?.contentIndex ?? index];
+  for (const mapping of mappings) {
+    const content = result.content[mapping.contentIndex];
     if (content?.type !== 'text') return undefined;
-    const requestedUri = mapping?.requestedUri ?? uri;
-    const canonicalUri = mapping?.canonicalUri ?? uri;
+    const requestedUri = mapping.requestedUri;
+    const canonicalUri = mapping.canonicalUri;
     if (memoryIdFromIdentityAlias(requestedUri) !== undefined) {
       resources.push({requestedUri, text: content.text, uri: requestedUri});
       continue;
@@ -1353,6 +1375,12 @@ function memoryReadResourcesFromNativeResult(
     });
   }
   return resources;
+}
+
+function canonicalReadMissing(result: CallToolResult): readonly string[] {
+  const value = result._meta?.['threadnote.io/canonical-read'];
+  if (!Predicate.isObject(value) || !Array.isArray(value.missing)) return [];
+  return value.missing.filter((uri): uri is string => typeof uri === 'string');
 }
 
 function canonicalReadMetadata(result: CallToolResult):

--- a/src/memory/code_citation_capture.ts
+++ b/src/memory/code_citation_capture.ts
@@ -107,6 +107,7 @@ export const captureMemoryCodeCitations = Effect.fn('memoryCodeCitation.capture'
   input: {
     readonly callerCwd: string;
     readonly expectedCallerIdentity?: ExpectedMemoryCodeCitationCallerIdentity;
+    readonly omitUnresolved?: boolean;
     readonly refs?: readonly string[];
   },
 ) {
@@ -152,7 +153,13 @@ export const captureMemoryCodeCitations = Effect.fn('memoryCodeCitation.capture'
   const capturedGroups = yield* Effect.forEach(
     [...groups.entries()],
     ([cwd, group]) =>
-      captureRepositoryGroup(config, cwd, group, cwd === input.callerCwd ? input.expectedCallerIdentity : undefined),
+      captureRepositoryGroup(
+        config,
+        cwd,
+        group,
+        cwd === input.callerCwd ? input.expectedCallerIdentity : undefined,
+        input.omitUnresolved === true,
+      ),
     {concurrency: 4},
   );
   if (input.expectedCallerIdentity) {
@@ -227,6 +234,7 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
   cwd: string,
   targets: readonly CaptureTarget[],
   expectedCallerIdentity?: ExpectedMemoryCodeCitationCallerIdentity,
+  omitUnresolved = false,
 ) {
   const query = yield* CodeGraphQueryService;
   const store = yield* CodeGraphStore;
@@ -353,6 +361,7 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
             if (target.target.kind === 'file') {
               const file = fileByPath.get(target.target.path);
               if (!file) {
+                if (omitUnresolved) return undefined;
                 return yield* MemoryCodeCitationCaptureError.of(
                   `Code citation path is not present in the exact current graph: ${target.target.path}. Use a graph-indexed repository-relative path.`,
                   undefined,
@@ -363,6 +372,7 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
             }
             const symbol = symbolById.get(target.target.nodeId);
             if (!symbol) {
+              if (omitUnresolved) return undefined;
               return yield* MemoryCodeCitationCaptureError.of(
                 `Code graph symbol is absent from the exact current graph: ${target.target.nodeId}.`,
                 undefined,
@@ -375,6 +385,9 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
             return yield* captureSymbolCitation(before, snapshot, symbol, target.index, readSource);
           }).pipe(Effect.mapError(error => captureError(target.ref, error))),
         {concurrency: 4},
+      );
+      const capturedTargets = results.filter(
+        (result): result is NonNullable<(typeof results)[number]> => result !== undefined,
       );
 
       const after = yield* query
@@ -389,7 +402,7 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
         );
       }
       if (expectedCallerIdentity) yield* requireExpectedCallerIdentity(after, expectedCallerIdentity);
-      return results;
+      return capturedTargets;
     }),
   );
 });

--- a/src/memory/deferred_code_anchor.ts
+++ b/src/memory/deferred_code_anchor.ts
@@ -17,6 +17,7 @@ import {
 import {MEMORY_SCHEMA_VERSION, type MemoryCodeCitationV1} from './code_citation.js';
 import {discardMemoryRelocation} from './relocation.js';
 import {deferredCodeAnchorCaptureFailureItem} from './deferred_code_anchor_failure.js';
+import {scheduleDeferredCodeAnchorWorkspaceRefresh} from './deferred_code_anchor_scheduler.js';
 import {
   deferredCodeAnchorFinalizationVerified,
   memoryContentHash,
@@ -285,6 +286,12 @@ export const stageDeferredCodeAnchorIntent = Effect.fn('memoryCodeAnchor.stage')
     worktreeId: status.identity.worktreeId,
   };
   yield* writeDeferredCodeAnchorIntent(config, intent);
+  if (intent.recovery.preparation.target !== 'workset') {
+    yield* scheduleDeferredCodeAnchorWorkspaceRefresh(config, {
+      cwd: intent.callerCwd,
+      worktreeId: intent.worktreeId,
+    }).pipe(Effect.ignoreCause);
+  }
   return intent;
 });
 
@@ -705,7 +712,19 @@ const finalizeDeferredCodeAnchor = Effect.fn('memoryCodeAnchor.finalizeOne')(fun
   }).pipe(Effect.result);
   if (Result.isFailure(captured)) {
     const classified = deferredCodeAnchorCaptureFailureItem(captured.failure, entry.intent.memoryUri);
-    if (classified !== undefined) return classified;
+    if (classified !== undefined) {
+      if (
+        classified.state === 'pending' &&
+        classified.retryable === true &&
+        entry.intent.recovery.preparation.target !== 'workset'
+      ) {
+        yield* scheduleDeferredCodeAnchorWorkspaceRefresh(config, {
+          cwd: entry.intent.callerCwd,
+          worktreeId: entry.intent.worktreeId,
+        }).pipe(Effect.ignoreCause);
+      }
+      return classified;
+    }
     return {
       code: 'citation-capture-failed',
       memoryUri: entry.intent.memoryUri,
@@ -787,7 +806,7 @@ const writeDeferredCodeAnchorIntent = Effect.fn('memoryCodeAnchor.writeIntent')(
   yield* persistShardedDeferredCodeAnchorIntent(config, intent, `${JSON.stringify(intent, undefined, 2)}\n`);
 });
 
-const listDeferredCodeAnchorIntents = Effect.fn('memoryCodeAnchor.listIntents')(function* (
+export const listDeferredCodeAnchorIntents = Effect.fn('memoryCodeAnchor.listIntents')(function* (
   config: Pick<RuntimeConfig, 'account' | 'agentContextHome' | 'user'>,
 ) {
   const fs = yield* FileSystem.FileSystem;

--- a/src/memory/deferred_code_anchor.ts
+++ b/src/memory/deferred_code_anchor.ts
@@ -1,6 +1,6 @@
 import {DateTime, Effect, FileSystem, Option, Path, Predicate, Result} from 'effect';
-import {succeedUndefined} from '../effect/optional.js';
 import {CodeGraphQueryService} from '../code_graph/query.js';
+import {succeedUndefined} from '../effect/optional.js';
 import {sha256Hex} from '../effect/digest.js';
 import {isFileLockTimeout, withExclusiveFileLock} from '../effect/file_lock.js';
 import {withMemoryUriLocks} from '../effect/memory_lock.js';
@@ -16,6 +16,7 @@ import {
 } from './code_citation_capture.js';
 import {MEMORY_SCHEMA_VERSION, type MemoryCodeCitationV1} from './code_citation.js';
 import {discardMemoryRelocation} from './relocation.js';
+import {classifyDeferredCodeAnchorCallerCheckoutAdmission} from './deferred_code_anchor_checkout.js';
 import {deferredCodeAnchorCaptureFailureItem} from './deferred_code_anchor_failure.js';
 import {scheduleDeferredCodeAnchorWorkspaceRefresh} from './deferred_code_anchor_scheduler.js';
 import {
@@ -660,7 +661,6 @@ const finalizeDeferredCodeAnchor = Effect.fn('memoryCodeAnchor.finalizeOne')(fun
   entry: StoredDeferredCodeAnchorIntent,
 ) {
   const fs = yield* FileSystem.FileSystem;
-  const query = yield* CodeGraphQueryService;
   const admission = yield* withMemoryUriLocks(
     fs,
     config.agentContextHome,
@@ -679,19 +679,13 @@ const finalizeDeferredCodeAnchor = Effect.fn('memoryCodeAnchor.finalizeOne')(fun
           state: 'rejected' as const,
         };
       }
-      const status = yield* query.status(config.agentContextHome, entry.intent.callerCwd, {
-        observeWorktree: true,
-        requestMaintenance: false,
-      });
-      if (
-        status.identity.repositoryId !== entry.intent.repositoryId ||
-        status.identity.worktreeId !== entry.intent.worktreeId
-      ) {
+      const checkout = yield* classifyDeferredCodeAnchorCallerCheckoutAdmission(config.agentContextHome, entry.intent);
+      if (checkout.state === 'conflict') {
         yield* discardStoredDeferredCodeAnchorIntent(config, entry);
         return {
           item: {
             memoryUri: entry.intent.memoryUri,
-            reason: 'caller-repository-identity-changed',
+            reason: checkout.reason,
             state: 'conflict',
           } satisfies DeferredCodeAnchorFinalizeItemV1,
           state: 'rejected' as const,
@@ -708,6 +702,7 @@ const finalizeDeferredCodeAnchor = Effect.fn('memoryCodeAnchor.finalizeOne')(fun
       repositoryId: entry.intent.repositoryId,
       worktreeId: entry.intent.worktreeId,
     },
+    omitUnresolved: true,
     refs: entry.intent.codeRefs,
   }).pipe(Effect.result);
   if (Result.isFailure(captured)) {
@@ -745,6 +740,14 @@ const finalizeDeferredCodeAnchor = Effect.fn('memoryCodeAnchor.finalizeOne')(fun
         return {
           memoryUri: entry.intent.memoryUri,
           reason: currentEligibility.reason,
+          state: 'conflict',
+        } satisfies DeferredCodeAnchorFinalizeItemV1;
+      }
+      if (citations.length === 0) {
+        yield* discardStoredDeferredCodeAnchorIntent(config, entry);
+        return {
+          memoryUri: entry.intent.memoryUri,
+          reason: 'code-references-absent',
           state: 'conflict',
         } satisfies DeferredCodeAnchorFinalizeItemV1;
       }

--- a/src/memory/deferred_code_anchor_checkout.ts
+++ b/src/memory/deferred_code_anchor_checkout.ts
@@ -1,0 +1,81 @@
+import {Effect, FileSystem, Result, Schema} from 'effect';
+import {CodeGraphQueryService} from '../code_graph/query.js';
+import {resolveRepositoryIdentity} from '../code_graph/repository.js';
+import {CodeGraphRepositoryError} from '../code_graph/types.js';
+
+export type DeferredCodeAnchorCallerCheckoutObservation =
+  | {readonly state: 'missing'}
+  | {readonly state: 'unobserved'}
+  | {readonly repositoryId: string; readonly state: 'present'; readonly worktreeId: string};
+
+export type DeferredCodeAnchorCallerCheckoutAdmission =
+  | {readonly state: 'eligible'}
+  | {
+      readonly reason: 'caller-checkout-missing' | 'caller-repository-identity-changed';
+      readonly state: 'conflict';
+    };
+
+function isUnusableDeferredCodeAnchorCallerCheckout(error: unknown): boolean {
+  return Schema.is(CodeGraphRepositoryError)(error) && error.message.startsWith('Not a Git repository');
+}
+
+export const observeDeferredCodeAnchorCallerCheckout = Effect.fn('memoryCodeAnchor.observeCallerCheckout')(function* (
+  cwd: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  if (!(yield* fs.exists(cwd))) return {state: 'missing'} as const;
+  const identity = yield* resolveRepositoryIdentity(cwd).pipe(Effect.result);
+  if (Result.isSuccess(identity)) {
+    return {
+      repositoryId: identity.success.repositoryId,
+      state: 'present' as const,
+      worktreeId: identity.success.worktreeId,
+    };
+  }
+  if (isUnusableDeferredCodeAnchorCallerCheckout(identity.failure)) {
+    return {state: 'missing'} as const;
+  }
+  return {state: 'unobserved'} as const;
+});
+
+export const classifyDeferredCodeAnchorCallerCheckoutAdmission = Effect.fn(
+  'memoryCodeAnchor.classifyCallerCheckoutAdmission',
+)(function* (
+  threadnoteHome: string,
+  intent: {readonly callerCwd: string; readonly repositoryId: string; readonly worktreeId: string},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const query = yield* CodeGraphQueryService;
+  const checkout = yield* observeDeferredCodeAnchorCallerCheckout(intent.callerCwd);
+  if (checkout.state === 'missing') {
+    return {
+      reason: 'caller-checkout-missing',
+      state: 'conflict',
+    } satisfies DeferredCodeAnchorCallerCheckoutAdmission;
+  }
+  const status = yield* query
+    .status(threadnoteHome, intent.callerCwd, {
+      observeWorktree: true,
+      requestMaintenance: false,
+    })
+    .pipe(Effect.result);
+  if (Result.isFailure(status)) {
+    if (isUnusableDeferredCodeAnchorCallerCheckout(status.failure) || !(yield* fs.exists(intent.callerCwd))) {
+      return {
+        reason: 'caller-checkout-missing',
+        state: 'conflict',
+      } satisfies DeferredCodeAnchorCallerCheckoutAdmission;
+    }
+    return yield* Effect.fail(status.failure);
+  }
+  if (
+    status.success.identity.repositoryId !== intent.repositoryId ||
+    status.success.identity.worktreeId !== intent.worktreeId
+  ) {
+    return {
+      reason: 'caller-repository-identity-changed',
+      state: 'conflict',
+    } satisfies DeferredCodeAnchorCallerCheckoutAdmission;
+  }
+  return {state: 'eligible'} satisfies DeferredCodeAnchorCallerCheckoutAdmission;
+});

--- a/src/memory/deferred_code_anchor_index_heal.ts
+++ b/src/memory/deferred_code_anchor_index_heal.ts
@@ -1,0 +1,45 @@
+import {Context, Effect} from 'effect';
+import type {CodeGraphIndexOptions, CodeGraphIndexerShape} from '../code_graph/indexer_types.js';
+import type {CodeGraphIndexSummary, RepositoryIdentity} from '../code_graph/types.js';
+import {getRuntimeConfig} from '../runtime.js';
+import {healAnchorsAfterGraphIndex} from './deferred_code_anchor_recovery.js';
+
+export function withDeferredCodeAnchorIndexHeal(
+  indexer: CodeGraphIndexerShape,
+  afterIndex: (options: CodeGraphIndexOptions, summary: CodeGraphIndexSummary) => Effect.Effect<void, unknown>,
+): CodeGraphIndexerShape {
+  return {
+    ensureCommit: options => indexer.ensureCommit(options),
+    index: options =>
+      indexer.index(options).pipe(Effect.tap(summary => afterIndex(options, summary).pipe(Effect.ignoreCause))),
+  };
+}
+
+const publishedGraphIndexHeal = (
+  threadnoteHome: string,
+  cwd: string,
+  identity: Pick<RepositoryIdentity, 'repositoryId' | 'worktreeId'>,
+) =>
+  getRuntimeConfig({home: threadnoteHome}).pipe(
+    Effect.flatMap(config => healAnchorsAfterGraphIndex(config, cwd, identity)),
+    Effect.ignoreCause,
+  );
+
+type PublishedGraphIndexHealServices = Effect.Services<ReturnType<typeof publishedGraphIndexHeal>>;
+
+function isFiberServiceContext<R>(_context: Context.Context<never>): _context is Context.Context<R> {
+  return true;
+}
+
+export const healAfterPublishedGraphIndex = (
+  threadnoteHome: string,
+  cwd: string,
+  identity: Pick<RepositoryIdentity, 'repositoryId' | 'worktreeId'>,
+): Effect.Effect<void> =>
+  Effect.withFiber(fiber => {
+    const context = fiber.context;
+    if (!isFiberServiceContext<PublishedGraphIndexHealServices>(context)) {
+      return Effect.void;
+    }
+    return publishedGraphIndexHeal(threadnoteHome, cwd, identity).pipe(Effect.setContext(context), Effect.asVoid);
+  });

--- a/src/memory/deferred_code_anchor_refresh.ts
+++ b/src/memory/deferred_code_anchor_refresh.ts
@@ -1,9 +1,16 @@
 import {Effect, Layer} from 'effect';
-import {resolveRepositoryIdentity} from '../code_graph/repository.js';
 import {CodeGraphWatcher} from '../code_graph/watcher.js';
-import {succeedUndefined} from '../effect/optional.js';
 import type {RuntimeConfig} from '../types.js';
-import {listDeferredCodeAnchorIntents, type DeferredCodeAnchorIntentV1} from './deferred_code_anchor.js';
+import {
+  finalizeDeferredCodeAnchors,
+  listDeferredCodeAnchorIntents,
+  MAX_DEFERRED_CODE_ANCHOR_FINALIZE_LIMIT,
+  type DeferredCodeAnchorIntentV1,
+} from './deferred_code_anchor.js';
+import {
+  observeDeferredCodeAnchorCallerCheckout,
+  type DeferredCodeAnchorCallerCheckoutObservation,
+} from './deferred_code_anchor_checkout.js';
 import {
   DeferredCodeAnchorRefreshScheduler,
   scheduleDeferredCodeAnchorWorkspaceRefresh,
@@ -22,17 +29,18 @@ export interface DeferredCodeAnchorWorkspaceRefreshTarget {
 
 export function selectDeferredCodeAnchorWorkspaceRefreshTargets(
   intents: readonly DeferredCodeAnchorIntentV1[],
-  identityByCwd: ReadonlyMap<string, {readonly repositoryId: string; readonly worktreeId: string} | undefined>,
+  observationByCwd: ReadonlyMap<string, DeferredCodeAnchorCallerCheckoutObservation>,
 ): readonly DeferredCodeAnchorWorkspaceRefreshTarget[] {
   const seen = new Set<string>();
   const targets: DeferredCodeAnchorWorkspaceRefreshTarget[] = [];
   for (const intent of intents) {
     if (intent.recovery.preparation.target === 'workset') continue;
-    const identity = identityByCwd.get(intent.callerCwd);
+    const observation = observationByCwd.get(intent.callerCwd);
     if (
-      identity === undefined ||
-      identity.repositoryId !== intent.repositoryId ||
-      identity.worktreeId !== intent.worktreeId
+      observation === undefined ||
+      observation.state !== 'present' ||
+      observation.repositoryId !== intent.repositoryId ||
+      observation.worktreeId !== intent.worktreeId
     ) {
       continue;
     }
@@ -47,22 +55,32 @@ export function selectDeferredCodeAnchorWorkspaceRefreshTargets(
   return targets;
 }
 
+export function selectDeferredCodeAnchorMissingCheckoutIntents(
+  intents: readonly DeferredCodeAnchorIntentV1[],
+  observationByCwd: ReadonlyMap<string, DeferredCodeAnchorCallerCheckoutObservation>,
+): readonly DeferredCodeAnchorIntentV1[] {
+  return intents.filter(intent => observationByCwd.get(intent.callerCwd)?.state === 'missing');
+}
+
+const observeDeferredCodeAnchorCallerCheckouts = Effect.fn('memoryCodeAnchor.observeCallerCheckouts')(function* (
+  intents: readonly DeferredCodeAnchorIntentV1[],
+) {
+  const observationByCwd = new Map<string, DeferredCodeAnchorCallerCheckoutObservation>();
+  for (const cwd of new Set(intents.map(intent => intent.callerCwd))) {
+    observationByCwd.set(cwd, yield* observeDeferredCodeAnchorCallerCheckout(cwd));
+  }
+  return observationByCwd;
+});
+
 export const listDeferredCodeAnchorWorkspaceRefreshTargets = Effect.fn('memoryCodeAnchor.listWorkspaceRefreshTargets')(
   function* (config: Pick<RuntimeConfig, 'account' | 'agentContextHome' | 'user'>) {
     const intents = (yield* listDeferredCodeAnchorIntents(config)).flatMap(entry =>
       entry.kind === 'valid' ? [entry.intent] : [],
     );
-    const identityByCwd = new Map<string, {readonly repositoryId: string; readonly worktreeId: string} | undefined>();
-    for (const cwd of new Set(intents.map(intent => intent.callerCwd))) {
-      identityByCwd.set(
-        cwd,
-        yield* resolveRepositoryIdentity(cwd).pipe(
-          Effect.map(identity => ({repositoryId: identity.repositoryId, worktreeId: identity.worktreeId})),
-          Effect.catch(() => succeedUndefined),
-        ),
-      );
-    }
-    return selectDeferredCodeAnchorWorkspaceRefreshTargets(intents, identityByCwd);
+    return selectDeferredCodeAnchorWorkspaceRefreshTargets(
+      intents,
+      yield* observeDeferredCodeAnchorCallerCheckouts(intents),
+    );
   },
 );
 
@@ -86,9 +104,23 @@ export const deferredCodeAnchorRefreshSchedulerLayer = Layer.effect(
 
 export const refreshPendingDeferredCodeAnchorWorkspaces = Effect.fn('memoryCodeAnchor.refreshPendingWorkspaces')(
   function* (config: RuntimeConfig) {
-    const targets = yield* listDeferredCodeAnchorWorkspaceRefreshTargets(config);
+    const intents = (yield* listDeferredCodeAnchorIntents(config)).flatMap(entry =>
+      entry.kind === 'valid' ? [entry.intent] : [],
+    );
+    const observationByCwd = yield* observeDeferredCodeAnchorCallerCheckouts(intents);
+    const missingUris = [
+      ...new Set(
+        selectDeferredCodeAnchorMissingCheckoutIntents(intents, observationByCwd).map(intent => intent.memoryUri),
+      ),
+    ];
+    if (missingUris.length > 0) {
+      yield* finalizeDeferredCodeAnchors(config, {
+        limit: Math.min(missingUris.length, MAX_DEFERRED_CODE_ANCHOR_FINALIZE_LIMIT),
+        uris: missingUris,
+      }).pipe(Effect.ignoreCause);
+    }
     yield* Effect.forEach(
-      targets,
+      selectDeferredCodeAnchorWorkspaceRefreshTargets(intents, observationByCwd),
       target => scheduleDeferredCodeAnchorWorkspaceRefresh(config, target).pipe(Effect.ignoreCause),
       {concurrency: 1},
     );

--- a/src/memory/deferred_code_anchor_refresh.ts
+++ b/src/memory/deferred_code_anchor_refresh.ts
@@ -1,0 +1,96 @@
+import {Effect, Layer} from 'effect';
+import {resolveRepositoryIdentity} from '../code_graph/repository.js';
+import {CodeGraphWatcher} from '../code_graph/watcher.js';
+import {succeedUndefined} from '../effect/optional.js';
+import type {RuntimeConfig} from '../types.js';
+import {listDeferredCodeAnchorIntents, type DeferredCodeAnchorIntentV1} from './deferred_code_anchor.js';
+import {
+  DeferredCodeAnchorRefreshScheduler,
+  scheduleDeferredCodeAnchorWorkspaceRefresh,
+} from './deferred_code_anchor_scheduler.js';
+
+export {
+  DeferredCodeAnchorRefreshScheduler,
+  scheduleDeferredCodeAnchorWorkspaceRefresh,
+} from './deferred_code_anchor_scheduler.js';
+
+export interface DeferredCodeAnchorWorkspaceRefreshTarget {
+  readonly cwd: string;
+  readonly repositoryId: string;
+  readonly worktreeId: string;
+}
+
+export function selectDeferredCodeAnchorWorkspaceRefreshTargets(
+  intents: readonly DeferredCodeAnchorIntentV1[],
+  identityByCwd: ReadonlyMap<string, {readonly repositoryId: string; readonly worktreeId: string} | undefined>,
+): readonly DeferredCodeAnchorWorkspaceRefreshTarget[] {
+  const seen = new Set<string>();
+  const targets: DeferredCodeAnchorWorkspaceRefreshTarget[] = [];
+  for (const intent of intents) {
+    if (intent.recovery.preparation.target === 'workset') continue;
+    const identity = identityByCwd.get(intent.callerCwd);
+    if (
+      identity === undefined ||
+      identity.repositoryId !== intent.repositoryId ||
+      identity.worktreeId !== intent.worktreeId
+    ) {
+      continue;
+    }
+    if (seen.has(intent.worktreeId)) continue;
+    seen.add(intent.worktreeId);
+    targets.push({
+      cwd: intent.callerCwd,
+      repositoryId: intent.repositoryId,
+      worktreeId: intent.worktreeId,
+    });
+  }
+  return targets;
+}
+
+export const listDeferredCodeAnchorWorkspaceRefreshTargets = Effect.fn('memoryCodeAnchor.listWorkspaceRefreshTargets')(
+  function* (config: Pick<RuntimeConfig, 'account' | 'agentContextHome' | 'user'>) {
+    const intents = (yield* listDeferredCodeAnchorIntents(config)).flatMap(entry =>
+      entry.kind === 'valid' ? [entry.intent] : [],
+    );
+    const identityByCwd = new Map<string, {readonly repositoryId: string; readonly worktreeId: string} | undefined>();
+    for (const cwd of new Set(intents.map(intent => intent.callerCwd))) {
+      identityByCwd.set(
+        cwd,
+        yield* resolveRepositoryIdentity(cwd).pipe(
+          Effect.map(identity => ({repositoryId: identity.repositoryId, worktreeId: identity.worktreeId})),
+          Effect.catch(() => succeedUndefined),
+        ),
+      );
+    }
+    return selectDeferredCodeAnchorWorkspaceRefreshTargets(intents, identityByCwd);
+  },
+);
+
+export const deferredCodeAnchorRefreshSchedulerLayer = Layer.effect(
+  DeferredCodeAnchorRefreshScheduler,
+  Effect.gen(function* () {
+    const watcher = yield* CodeGraphWatcher;
+    return DeferredCodeAnchorRefreshScheduler.of({
+      schedule: options =>
+        watcher
+          .refresh({
+            admissionClass: 'background',
+            cwd: options.cwd,
+            key: options.key,
+            threadnoteHome: options.threadnoteHome,
+          })
+          .pipe(Effect.asVoid, Effect.ignoreCause),
+    });
+  }),
+);
+
+export const refreshPendingDeferredCodeAnchorWorkspaces = Effect.fn('memoryCodeAnchor.refreshPendingWorkspaces')(
+  function* (config: RuntimeConfig) {
+    const targets = yield* listDeferredCodeAnchorWorkspaceRefreshTargets(config);
+    yield* Effect.forEach(
+      targets,
+      target => scheduleDeferredCodeAnchorWorkspaceRefresh(config, target).pipe(Effect.ignoreCause),
+      {concurrency: 1},
+    );
+  },
+);

--- a/src/memory/deferred_code_anchor_scheduler.ts
+++ b/src/memory/deferred_code_anchor_scheduler.ts
@@ -1,0 +1,30 @@
+import {Context, Effect, Option} from 'effect';
+import type {RuntimeConfig} from '../types.js';
+
+export interface DeferredCodeAnchorRefreshSchedulerShape {
+  readonly schedule: (options: {
+    readonly cwd: string;
+    readonly key: string;
+    readonly threadnoteHome: string;
+  }) => Effect.Effect<void>;
+}
+
+export class DeferredCodeAnchorRefreshScheduler extends Context.Service<
+  DeferredCodeAnchorRefreshScheduler,
+  DeferredCodeAnchorRefreshSchedulerShape
+>()('threadnote/memory/deferred_code_anchor_scheduler/DeferredCodeAnchorRefreshScheduler') {}
+
+export const scheduleDeferredCodeAnchorWorkspaceRefresh = Effect.fn('memoryCodeAnchor.scheduleWorkspaceRefresh')(
+  function* (
+    config: Pick<RuntimeConfig, 'agentContextHome'>,
+    target: {readonly cwd: string; readonly worktreeId: string},
+  ) {
+    const scheduler = yield* Effect.serviceOption(DeferredCodeAnchorRefreshScheduler);
+    if (Option.isNone(scheduler)) return;
+    yield* scheduler.value.schedule({
+      cwd: target.cwd,
+      key: target.worktreeId,
+      threadnoteHome: config.agentContextHome,
+    });
+  },
+);

--- a/src/process/diagnostics.ts
+++ b/src/process/diagnostics.ts
@@ -5,6 +5,7 @@ import {SystemInfo} from '../effect/system.js';
 import {readLiveStandaloneProcessLeases} from './standalone_lease.js';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {orderThreadnoteProcessesByAttention} from './attention.js';
+import {observeProcessInstanceIdentity, processInstanceIdentityMatches} from './process_identity.js';
 import {withoutTelemetrySessionEnvironment} from '../telemetry/session.js';
 
 const PROCESS_DIAGNOSTICS_SCHEMA_VERSION = 1;
@@ -255,15 +256,22 @@ const readThreadnoteProcessSnapshot = Effect.fn('processDiagnostics.readSnapshot
     }
     const value = candidate.value.value;
     const running = system.isProcessRunning(value.processId);
-    const identity =
-      running && value.processStartIdentity ? yield* system.processStartIdentity(value.processId) : undefined;
-    const identityMatches =
-      value.processStartIdentity === undefined || identity === undefined || identity === value.processStartIdentity;
+    const identity = running ? yield* observeProcessInstanceIdentity(system, value.processId) : undefined;
+    const identityMatches = processInstanceIdentityMatches(value.processStartIdentity, identity);
     if (!running || !identityMatches) {
       yield* removeRegistrationFile(fs, candidate.file);
       continue;
     }
-    live.push(value);
+    const kept =
+      identity !== undefined && value.processStartIdentity !== undefined && value.processStartIdentity !== identity
+        ? {...value, processStartIdentity: identity}
+        : value;
+    if (kept !== value) {
+      yield* fs
+        .writeFileString(candidate.file, `${JSON.stringify(kept, undefined, 2)}\n`, {mode: 0o600})
+        .pipe(Effect.ignore);
+    }
+    live.push(kept);
   }
 
   // Standalone releases before the runtime registry still retain a private,
@@ -523,7 +531,7 @@ function registerThreadnoteProcess(home: string, baseRole: RegisteredThreadnoteP
       fileSystem: fs,
       parentProcessId: process.ppid,
       processId: system.processId,
-      processStartIdentity: yield* system.processStartIdentity(system.processId),
+      processStartIdentity: yield* observeProcessInstanceIdentity(system, system.processId),
       originalTitle: process.title,
       path,
       startedAt: DateTime.formatIso(yield* DateTime.now),
@@ -717,7 +725,8 @@ function isProcessReference(value: string): boolean {
 function registrationMatchesRunningProcess(system: SystemInfo['Service'], value: ProcessRegistrationFile) {
   return Effect.gen(function* () {
     if (!system.isProcessRunning(value.processId) || value.processStartIdentity === undefined) return false;
-    return (yield* system.processStartIdentity(value.processId)) === value.processStartIdentity;
+    const identity = yield* observeProcessInstanceIdentity(system, value.processId);
+    return identity === value.processStartIdentity;
   });
 }
 
@@ -768,7 +777,7 @@ function signalVerifiedProcess(
         'The selected process instance changed. Refresh the process list and try again.',
       );
     }
-    const identity = yield* system.processStartIdentity(registration.processId);
+    const identity = yield* observeProcessInstanceIdentity(system, registration.processId);
     if (identity !== registration.processStartIdentity) {
       return yield* ThreadnoteProcessTerminationError.of(
         'process-stale',
@@ -822,9 +831,9 @@ function processInstanceIsRunning(system: SystemInfo['Service'], registration: P
   if (!system.isProcessRunning(registration.processId) || registration.processStartIdentity === undefined) {
     return Effect.succeed(false);
   }
-  return system
-    .processStartIdentity(registration.processId)
-    .pipe(Effect.map(identity => identity === registration.processStartIdentity));
+  return observeProcessInstanceIdentity(system, registration.processId).pipe(
+    Effect.map(identity => identity === registration.processStartIdentity),
+  );
 }
 
 function boundedTerminationWait(value: number | undefined, fallback: number): number {

--- a/src/process/diagnostics.ts
+++ b/src/process/diagnostics.ts
@@ -584,7 +584,10 @@ function writeCurrentRegistration(): Effect.Effect<void, unknown> {
         setBestEffortProcessTitle(role);
         const currentOperation = current?.operation ?? active.baseOperation;
         const stateKey = `${role}\0${currentOperation ?? ''}`;
-        if (active.queuedStateKey === stateKey) return;
+        if (active.queuedStateKey === stateKey) {
+          const exists = yield* active.fileSystem.exists(active.file).pipe(Effect.orElseSucceed(() => false));
+          if (exists) return;
+        }
         const value: ProcessRegistrationFile = {
           baseRole: active.baseRole,
           ...(currentOperation === undefined ? {} : {currentOperation}),

--- a/src/process/process_identity.ts
+++ b/src/process/process_identity.ts
@@ -1,0 +1,23 @@
+import {Effect} from 'effect';
+import {succeedUndefined} from '../effect/optional.js';
+import type {SystemInfoShape} from '../effect/system.js';
+
+const PRE_CANONICAL_DARWIN_PROCESS_IDENTITY = /^darwin:(?!v2:)./;
+
+export function observeProcessInstanceIdentity(
+  system: Pick<SystemInfoShape, 'canonicalProcessStartIdentity' | 'processStartIdentity'>,
+  processId: number,
+): Effect.Effect<string | undefined> {
+  return (system.canonicalProcessStartIdentity?.(processId) ?? succeedUndefined).pipe(
+    Effect.filterOrElse(
+      (canonical): canonical is string => canonical !== undefined,
+      () => system.processStartIdentity(processId),
+    ),
+  );
+}
+
+export function processInstanceIdentityMatches(stored: string | undefined, observed: string | undefined): boolean {
+  if (stored === undefined || observed === undefined) return true;
+  if (stored === observed) return true;
+  return PRE_CANONICAL_DARWIN_PROCESS_IDENTITY.test(stored) && observed.startsWith('darwin-v2:');
+}

--- a/src/process/process_identity.ts
+++ b/src/process/process_identity.ts
@@ -4,11 +4,18 @@ import type {SystemInfoShape} from '../effect/system.js';
 
 const PRE_CANONICAL_DARWIN_PROCESS_IDENTITY = /^darwin:(?!v2:)./;
 
+export function observeCanonicalProcessInstanceIdentity(
+  system: Pick<SystemInfoShape, 'canonicalProcessStartIdentity'>,
+  processId: number,
+): Effect.Effect<string | undefined> {
+  return system.canonicalProcessStartIdentity?.(processId) ?? succeedUndefined;
+}
+
 export function observeProcessInstanceIdentity(
   system: Pick<SystemInfoShape, 'canonicalProcessStartIdentity' | 'processStartIdentity'>,
   processId: number,
 ): Effect.Effect<string | undefined> {
-  return (system.canonicalProcessStartIdentity?.(processId) ?? succeedUndefined).pipe(
+  return observeCanonicalProcessInstanceIdentity(system, processId).pipe(
     Effect.filterOrElse(
       (canonical): canonical is string => canonical !== undefined,
       () => system.processStartIdentity(processId),
@@ -16,8 +23,19 @@ export function observeProcessInstanceIdentity(
   );
 }
 
+function isPreCanonicalDarwinProcessIdentity(identity: string): boolean {
+  return PRE_CANONICAL_DARWIN_PROCESS_IDENTITY.test(identity);
+}
+
+function isCanonicalDarwinProcessIdentity(identity: string): boolean {
+  return identity.startsWith('darwin-v2:');
+}
+
 export function processInstanceIdentityMatches(stored: string | undefined, observed: string | undefined): boolean {
   if (stored === undefined || observed === undefined) return true;
   if (stored === observed) return true;
-  return PRE_CANONICAL_DARWIN_PROCESS_IDENTITY.test(stored) && observed.startsWith('darwin-v2:');
+  return (
+    (isPreCanonicalDarwinProcessIdentity(stored) && isCanonicalDarwinProcessIdentity(observed)) ||
+    (isCanonicalDarwinProcessIdentity(stored) && isPreCanonicalDarwinProcessIdentity(observed))
+  );
 }

--- a/src/process/standalone_lease.ts
+++ b/src/process/standalone_lease.ts
@@ -1,5 +1,6 @@
 import {Crypto, DateTime, Effect, Exit, FileSystem, Option, Path, Schema} from 'effect';
 import {SystemInfo, type SystemInfoShape} from '../effect/system.js';
+import {observeProcessInstanceIdentity, processInstanceIdentityMatches} from './process_identity.js';
 import {compareVersions} from '../release/version_compare.js';
 
 class StandaloneProcessLeaseError extends Schema.TaggedError<StandaloneProcessLeaseError>()(
@@ -105,7 +106,7 @@ export function withStandaloneProcessLease<A, E, R>(
       if (!release) return yield* effect;
       const crypto = yield* Crypto.Crypto;
       const token = yield* crypto.randomUUIDv4;
-      const processStartIdentity = yield* system.processStartIdentity(system.processId);
+      const processStartIdentity = yield* observeProcessInstanceIdentity(system, system.processId);
       const leaseDirectory = path.join(root, 'leases', release.version);
       const leasePath = path.join(leaseDirectory, `${system.processId}.json`);
       yield* fs.makeDirectory(leaseDirectory, {recursive: true, mode: 0o700});
@@ -357,22 +358,29 @@ const liveStandaloneProcessLeases = Effect.fn('installations.liveProcessLeases')
         continue;
       }
       const processIsRunning = system.isProcessRunning(processId);
-      const currentProcessIdentity =
-        processIsRunning && Option.isSome(lease.value.processStartIdentity)
-          ? yield* system.processStartIdentity(processId)
-          : undefined;
-      const identityMatches =
-        Option.isNone(lease.value.processStartIdentity) ||
-        currentProcessIdentity === undefined ||
-        currentProcessIdentity === lease.value.processStartIdentity.value;
+      const currentProcessIdentity = processIsRunning
+        ? yield* observeProcessInstanceIdentity(system, processId)
+        : undefined;
+      const storedProcessIdentity = Option.getOrUndefined(lease.value.processStartIdentity);
+      const identityMatches = processInstanceIdentityMatches(storedProcessIdentity, currentProcessIdentity);
       if (processIsRunning && identityMatches) {
+        const processStartIdentity =
+          currentProcessIdentity !== undefined &&
+          storedProcessIdentity !== undefined &&
+          storedProcessIdentity !== currentProcessIdentity
+            ? Option.some(currentProcessIdentity)
+            : lease.value.processStartIdentity;
+        if (Option.isSome(processStartIdentity) && processStartIdentity.value !== storedProcessIdentity) {
+          yield* rewriteLeaseProcessStartIdentity(fs, leasePath, processStartIdentity.value).pipe(Effect.ignore);
+        }
         live.push({
           identityVerified:
-            Option.isSome(lease.value.processStartIdentity) &&
-            currentProcessIdentity === lease.value.processStartIdentity.value,
+            Option.isSome(processStartIdentity) &&
+            currentProcessIdentity !== undefined &&
+            processStartIdentity.value === currentProcessIdentity,
           parentProcessId: lease.value.parentProcessId,
           processId,
-          processStartIdentity: lease.value.processStartIdentity,
+          processStartIdentity,
           retirementPolicy: lease.value.retirementPolicy,
           startedAt: lease.value.startedAt,
           version,
@@ -431,7 +439,7 @@ function signalLeaseIfStillOwned(
 ): Effect.Effect<boolean> {
   return Effect.gen(function* () {
     if (!system.isProcessRunning(lease.processId) || Option.isNone(lease.processStartIdentity)) return false;
-    const identity = yield* system.processStartIdentity(lease.processId);
+    const identity = yield* observeProcessInstanceIdentity(system, lease.processId);
     if (identity !== lease.processStartIdentity.value) return false;
     return yield* Effect.try({
       try: () => {
@@ -477,6 +485,23 @@ function removeOwnedLease(fs: FileSystem.FileSystem, leasePath: string, token: s
   return Effect.gen(function* () {
     if ((yield* readLeaseToken(fs, leasePath)) === token) yield* fs.remove(leasePath, {force: true});
   }).pipe(Effect.ignore);
+}
+
+function rewriteLeaseProcessStartIdentity(fs: FileSystem.FileSystem, leasePath: string, processStartIdentity: string) {
+  return fs.readFileString(leasePath).pipe(
+    Effect.flatMap(content => {
+      let value: unknown;
+      try {
+        value = JSON.parse(content) as unknown;
+      } catch {
+        return Effect.void;
+      }
+      if (typeof value !== 'object' || value === null) return Effect.void;
+      return fs.writeFileString(leasePath, `${JSON.stringify({...value, processStartIdentity}, undefined, 2)}\n`, {
+        mode: 0o600,
+      });
+    }),
+  );
 }
 
 function readLeaseToken(fs: FileSystem.FileSystem, leasePath: string) {

--- a/src/recall/runtime.ts
+++ b/src/recall/runtime.ts
@@ -470,6 +470,8 @@ const prepareRecallSectionsAttempt = Effect.fn('recall.prepareSectionsAttempt')(
       );
   const unreadIndexedMemoryUris = unreadIndexedMemoryRecordUris(indexedCandidates, records);
   const extraRecords = unreadIndexedMemoryUris.length > 0 ? yield* input.readRecords(unreadIndexedMemoryUris) : [];
+  const extraRecordUris = new Set(extraRecords.map(record => record.uri.replace(/#.*$/, '')));
+  const absentMemoryUris = unreadIndexedMemoryUris.filter(uri => !extraRecordUris.has(uri.replace(/#.*$/, '')));
   const liveRecords = extraRecords.length > 0 ? [...records, ...extraRecords] : records;
   const expansionCandidates = mergeRecallExpansionCandidates(
     recallIndexCandidateSets,
@@ -477,6 +479,7 @@ const prepareRecallSectionsAttempt = Effect.fn('recall.prepareSectionsAttempt')(
     topicalRecallIndexCandidateSets.length,
   ).filter(candidate => recallRuntimeCandidateIsEligible(candidate, input.eligibility));
   const sections = buildRecallSections(input.passes, input.exactMatches, input.limit, {
+    absentMemoryUris,
     allowExactRescue: input.allowExactRescue,
     allowedUriScopes: input.allowedUriScopes,
     candidateUris: input.candidateUris,

--- a/src/recall/runtime.ts
+++ b/src/recall/runtime.ts
@@ -468,6 +468,9 @@ const prepareRecallSectionsAttempt = Effect.fn('recall.prepareSectionsAttempt')(
           }),
         ),
       );
+  const unreadIndexedMemoryUris = unreadIndexedMemoryRecordUris(indexedCandidates, records);
+  const extraRecords = unreadIndexedMemoryUris.length > 0 ? yield* input.readRecords(unreadIndexedMemoryUris) : [];
+  const liveRecords = extraRecords.length > 0 ? [...records, ...extraRecords] : records;
   const expansionCandidates = mergeRecallExpansionCandidates(
     recallIndexCandidateSets,
     rankingUris,
@@ -487,7 +490,7 @@ const prepareRecallSectionsAttempt = Effect.fn('recall.prepareSectionsAttempt')(
     project: input.project,
     query: input.query,
     queryVariants,
-    records,
+    records: liveRecords,
     protectedUris: memoryConnections?.candidates.map(candidate => candidate.uri),
     seedUris: input.seedUris,
     workspaceBranch: input.workspaceBranch,
@@ -892,6 +895,23 @@ function applyCachedRerankerScores(
 
 function rerankerCacheKey(candidate: RecallCandidate): string {
   return `${candidate.uri}\u0000${candidate.text}`;
+}
+
+function unreadIndexedMemoryRecordUris(
+  indexedCandidates: readonly RecallCandidate[],
+  records: readonly MemoryRecord[],
+): readonly string[] {
+  const live = new Set(records.map(record => record.uri.replace(/#.*$/, '')));
+  const unread = new Set<string>();
+  for (const candidate of indexedCandidates) {
+    for (const uri of [candidate.uri, ...(candidate.equivalentUris ?? [])]) {
+      const documentUri = uri.replace(/#.*$/, '');
+      if (documentUri.includes('/memories/') && !live.has(documentUri)) {
+        unread.add(documentUri);
+      }
+    }
+  }
+  return [...unread];
 }
 
 export function buildRecallSelectionCandidates(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1658,6 +1658,11 @@ function hybridRankRecallHits(
       validTo: record?.metadata.validTo ?? indexed?.validTo,
     } satisfies RecallCandidate;
   });
+  const liveRecordsProvided = context.records !== undefined;
+  const hasLiveMemoryRecord = (uri: string, equivalentUris?: readonly string[]) =>
+    !liveRecordsProvided ||
+    !uri.includes('/memories/') ||
+    [uri, ...(equivalentUris ?? [])].some(candidateUri => recordsByUri.has(stripAnchor(candidateUri)));
   const hitUris = new Set(hitCandidates.map(candidate => candidate.uri));
   const candidates = [
     ...hitCandidates,
@@ -1668,7 +1673,7 @@ function hybridRankRecallHits(
         feedback: context.feedbackByUri?.get(stripAnchor(candidate.uri)),
         uri: stripAnchor(candidate.uri),
       })),
-  ];
+  ].filter(candidate => hasLiveMemoryRecord(candidate.uri, candidate.equivalentUris));
   for (const candidate of candidates) {
     if (!byUri.has(candidate.uri)) {
       const category = categoryForUri(candidate.uri);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1658,7 +1658,9 @@ function hybridRankRecallHits(
       validTo: record?.metadata.validTo ?? indexed?.validTo,
     } satisfies RecallCandidate;
   });
-  const liveRecordsProvided = context.records !== undefined;
+  // Empty `records` is an unchecked load (stubs, or hydration that returned
+  // nothing). Only a non-empty loaded set can prove a memory URI was absent.
+  const liveRecordsProvided = (context.records?.length ?? 0) > 0;
   const hasLiveMemoryRecord = (uri: string, equivalentUris?: readonly string[]) =>
     !liveRecordsProvided ||
     !uri.includes('/memories/') ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1509,6 +1509,8 @@ export function recallIndexPreselectionLimit(resultLimit: number): number {
 }
 
 interface HybridRecallOptions extends RecallRankContext {
+  /** Memory URIs extra hydration requested and did not return, even when `records` is empty. */
+  readonly absentMemoryUris?: readonly string[];
   readonly allowedUriScopes?: readonly string[];
   readonly candidateUris?: readonly string[];
   readonly feedbackByUri?: ReadonlyMap<string, number>;
@@ -1659,12 +1661,20 @@ function hybridRankRecallHits(
     } satisfies RecallCandidate;
   });
   // Empty `records` is an unchecked load (stubs, or hydration that returned
-  // nothing). Only a non-empty loaded set can prove a memory URI was absent.
+  // nothing). Only a non-empty loaded set can prove a memory URI was absent,
+  // unless extra hydration already requested that URI and missed.
+  const absentMemoryUris = new Set((context.absentMemoryUris ?? []).map(uri => stripAnchor(uri)));
   const liveRecordsProvided = (context.records?.length ?? 0) > 0;
-  const hasLiveMemoryRecord = (uri: string, equivalentUris?: readonly string[]) =>
-    !liveRecordsProvided ||
-    !uri.includes('/memories/') ||
-    [uri, ...(equivalentUris ?? [])].some(candidateUri => recordsByUri.has(stripAnchor(candidateUri)));
+  const hasLiveMemoryRecord = (uri: string, equivalentUris?: readonly string[]) => {
+    const candidateUris = [uri, ...(equivalentUris ?? [])];
+    if (candidateUris.some(candidateUri => recordsByUri.has(stripAnchor(candidateUri)))) {
+      return true;
+    }
+    if (candidateUris.some(candidateUri => absentMemoryUris.has(stripAnchor(candidateUri)))) {
+      return false;
+    }
+    return !liveRecordsProvided || !uri.includes('/memories/');
+  };
   const hitUris = new Set(hitCandidates.map(candidate => candidate.uri));
   const candidates = [
     ...hitCandidates,

--- a/test/integration/context-brief-deferred-autoheal.test.ts
+++ b/test/integration/context-brief-deferred-autoheal.test.ts
@@ -79,6 +79,15 @@ describe('Context Brief deferred code-anchor recovery', () => {
             };
             const body = 'The deferred backlink must appear in the first post-ready Context Brief.';
             const content = formatMemoryDocument('MEMORY', metadata, body);
+            const store = yield* ResourceStore;
+            const location = {account: config.account, home, user: config.user} as const;
+            const indexer = yield* CodeGraphIndexer;
+            // Index before staging so wrap-heal cannot consume the intent; this
+            // example is the missed-wakeup path after a ready graph already exists.
+            yield* indexer
+              .index({cwd: repository, ensureVectors: false, threadnoteHome: home})
+              .pipe(TestClock.withLive);
+            yield* store.write(location, memoryUri, content, {mode: 'create'});
             yield* stageDeferredCodeAnchorIntent(config, {
               memoryContent: content,
               memoryMetadata: metadata,
@@ -104,15 +113,6 @@ describe('Context Brief deferred code-anchor recovery', () => {
                 },
               },
             });
-            const store = yield* ResourceStore;
-            const location = {account: config.account, home, user: config.user} as const;
-            yield* store.write(location, memoryUri, content, {mode: 'create'});
-            // The service-level indexer deliberately bypasses the CLI graph-index
-            // opportunity, leaving the consumer-side missed-wakeup fallback to prove.
-            const indexer = yield* CodeGraphIndexer;
-            yield* indexer
-              .index({cwd: repository, ensureVectors: false, threadnoteHome: home})
-              .pipe(TestClock.withLive);
             const pendingRoot = path.join(
               home,
               'data',

--- a/test/integration/recall.identifier-confidence.test.ts
+++ b/test/integration/recall.identifier-confidence.test.ts
@@ -3,6 +3,7 @@ import {DateTime, Effect, FileSystem, Option, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {ResourceStore, type ResourceStoreMutation} from '../../src/effect/resource-store.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {readMemoryRecordsByUri} from '../../src/memory/index.js';
 import {loadRecallIndex} from '../../src/recall/index.js';
 import {prepareRecallSections} from '../../src/recall/runtime.js';
 import type {RuntimeConfig} from '../../src/types.js';
@@ -82,7 +83,7 @@ effectIt.effect('recalls an exact camelCase identifier extracted from the canoni
         passes: [],
         project: 'threadnote',
         query: `Where is ${TARGET_IDENTIFIER} behavior defined?`,
-        readRecords: () => Effect.succeed([]),
+        readRecords: uris => readMemoryRecordsByUri(config, uris),
         semanticResult: Option.none(),
       });
 

--- a/test/integration/recall.workspace-selection.test.ts
+++ b/test/integration/recall.workspace-selection.test.ts
@@ -4,8 +4,21 @@ import {Effect, FileSystem, Option, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {expect} from 'vitest';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {readMemoryRecordsByUri} from '../../src/memory/index.js';
 import {loadRecallIndexData} from '../../src/recall/index.js';
 import {prepareRecallSections} from '../../src/recall/runtime.js';
+import type {RuntimeConfig} from '../../src/types.js';
+
+function liveRecordReader(home: string, user = 'me') {
+  const config: RuntimeConfig = {
+    account: 'local',
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath: `${home}/seed-manifest.yaml`,
+    user,
+  };
+  return (uris: readonly string[]) => readMemoryRecordsByUri(config, uris);
+}
 
 function memoryContent(
   topic: string,
@@ -105,7 +118,7 @@ effectIt.effect(
         passes: [],
         project: 'monorepo',
         query,
-        readRecords: () => Effect.succeed([]),
+        readRecords: liveRecordReader(home),
         semanticResult: Option.none(),
         workspaceScope: 'apps/search',
       });
@@ -207,7 +220,7 @@ effectIt.effect(
         passes: [],
         project: 'monorepo',
         query,
-        readRecords: () => Effect.succeed([]),
+        readRecords: liveRecordReader(home),
         semanticResult: Option.some({
           corpusGeneration: Option.some(globalTopical.generation),
           scores: Option.some(new Map([[targetUri, 0.9]])),
@@ -305,7 +318,7 @@ effectIt.effect(
         project: 'monorepo',
         query: originalQuery,
         queryVariants: [query],
-        readRecords: () => Effect.succeed([]),
+        readRecords: liveRecordReader(home),
         semanticResult: Option.none(),
         workspaceScope: 'apps/search',
       });
@@ -390,7 +403,7 @@ effectIt.effect(
         passes: [],
         project: 'monorepo',
         query,
-        readRecords: () => Effect.succeed([]),
+        readRecords: liveRecordReader(home),
         semanticResult: Option.none(),
         workspaceBranch: 'feature/search-recall',
       });

--- a/test/unit/code-graph.attach-shared-ready.test.ts
+++ b/test/unit/code-graph.attach-shared-ready.test.ts
@@ -212,4 +212,15 @@ describe('codeGraphWatcherRefreshIndexRequest', () => {
       threadnoteHome: '/home',
     });
   });
+
+  it('forwards a caller-supplied builder admission class', () => {
+    expect(
+      codeGraphWatcherRefreshIndexRequest({
+        admissionClass: 'background',
+        cwd: '/repo',
+        key: 'worktree',
+        threadnoteHome: '/home',
+      }),
+    ).toMatchObject({admissionClass: 'background', ensureVectors: false});
+  });
 });

--- a/test/unit/code-graph.isolated-builder.test.ts
+++ b/test/unit/code-graph.isolated-builder.test.ts
@@ -189,6 +189,16 @@ describe('isolated code-graph builder spawn plan', () => {
     expect(() => assertIsolatedBuilderPlan(plan)).not.toThrow();
   });
 
+  it('forwards background builder admission to isolated graph-index children', () => {
+    const plan = codeGraphIsolatedBuilderSpawnPlan(systemInfoStub({}), {
+      admissionClass: 'background',
+      cwd: '/repo/worktree',
+      threadnoteHome: '/home/.threadnote',
+    });
+    expect(plan.environment.THREADNOTE_CODE_GRAPH_BUILDER_ADMISSION_CLASS).toBe('background');
+    expect(() => assertIsolatedBuilderPlan(plan)).not.toThrow();
+  });
+
   it('forwards a Manager full rebuild without disabling vectors', () => {
     const plan = codeGraphIsolatedBuilderSpawnPlan(systemInfoStub({}), {
       cwd: '/repo/worktree',

--- a/test/unit/code-graph.watcher.test.ts
+++ b/test/unit/code-graph.watcher.test.ts
@@ -175,6 +175,34 @@ describe('CodeGraphWatcher', () => {
     }),
   );
 
+  effectIt.effect(
+    'keeps caller-supplied background admission on refresh and defaults inspect refresh to current-required',
+    () =>
+      Effect.gen(function* () {
+        const classes = yield* Ref.make<Array<CodeGraphWatchOptions['admissionClass']>>([]);
+        const watcher = yield* makeCodeGraphWatcher(
+          () => Effect.void,
+          refreshOptions => Ref.update(classes, current => [...current, refreshOptions.admissionClass]),
+        );
+
+        yield* watcher.refresh({...options, admissionClass: 'background', key: 'background'});
+        let observed = yield* Ref.get(classes);
+        for (let attempt = 0; attempt < 32 && observed.length < 1; attempt += 1) {
+          yield* Effect.yieldNow;
+          observed = yield* Ref.get(classes);
+        }
+        expect(observed).toEqual(['background']);
+
+        yield* watcher.refresh({...options, key: 'inspect'});
+        for (let attempt = 0; attempt < 32 && observed.length < 2; attempt += 1) {
+          yield* Effect.yieldNow;
+          observed = yield* Ref.get(classes);
+        }
+
+        expect(observed).toEqual(['background', 'current-required']);
+      }).pipe(Effect.scoped),
+  );
+
   effectIt.effect('starts a replacement watcher after the previous run terminates', () =>
     Effect.gen(function* () {
       const starts = yield* Effect.scoped(

--- a/test/unit/deferred-code-anchor-index-heal.test.ts
+++ b/test/unit/deferred-code-anchor-index-heal.test.ts
@@ -10,10 +10,16 @@ import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
 import {
+  deferredCodeAnchorDoctorCheck,
+  hasDeferredCodeAnchorIntent,
   isDeferredCodeAnchorIntentFilename,
   stageDeferredCodeAnchorIntent,
 } from '../../src/memory/deferred_code_anchor.js';
 import {withDeferredCodeAnchorIndexHeal} from '../../src/memory/deferred_code_anchor_index_heal.js';
+import {
+  DeferredCodeAnchorRefreshScheduler,
+  refreshPendingDeferredCodeAnchorWorkspaces,
+} from '../../src/memory/deferred_code_anchor_refresh.js';
 import {formatMemoryDocument, parseMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
@@ -217,6 +223,123 @@ describe('in-process graph-index deferred-anchor recovery', () => {
             memoryId: metadata.memoryId,
             status: metadata.status,
           });
+        }),
+      ).pipe(withTesterUser, provideTestLayer(ApplicationLayer)),
+    60_000,
+  );
+
+  effectIt.effect(
+    'does not rebind a deleted worktree intent onto a sibling checkout during wrap-heal',
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-wrap-heal-sibling-'});
+          const repository = path.join(root, 'repository');
+          const sibling = path.join(root, 'sibling');
+          const home = path.join(root, 'home');
+          const manifestPath = path.join(home, 'seed-manifest.yaml');
+          yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
+          yield* fs.makeDirectory(home, {recursive: true});
+          yield* fs.writeFileString(path.join(repository, 'src', 'heal.ts'), 'export const wrapHeal = "ready";\n');
+          yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
+          yield* runCommandEffect('git', ['init', '--quiet'], {cwd: repository}).pipe(TestClock.withLive);
+          yield* runCommandEffect('git', ['add', '.'], {cwd: repository}).pipe(TestClock.withLive);
+          yield* runCommandEffect(
+            'git',
+            [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '--quiet',
+              '--message',
+              'fixture',
+            ],
+            {cwd: repository},
+          ).pipe(TestClock.withLive);
+          yield* runCommandEffect('git', ['worktree', 'add', '--quiet', sibling, 'HEAD'], {cwd: repository}).pipe(
+            TestClock.withLive,
+          );
+
+          const config: RuntimeConfig = {
+            account: 'local',
+            agentContextHome: home,
+            agentId: 'threadnote',
+            manifestPath,
+            user: 'tester',
+          };
+          const metadata: MemoryMetadata = {
+            kind: 'durable',
+            memoryId: 'tn_wrap_heal_sibling',
+            project: 'threadnote',
+            schemaVersion: MEMORY_SCHEMA_VERSION,
+            sourceAgentClient: 'test',
+            status: 'active',
+            timestamp: '2026-09-10T00:00:00.000Z',
+            topic: 'wrap-heal-sibling',
+            visibility: 'personal',
+          };
+          const body = 'Deleted sibling worktree must stay uncited.';
+          const content = formatMemoryDocument('MEMORY', metadata, body);
+          const store = yield* ResourceStore;
+          const location = {account: config.account, home, user: config.user} as const;
+          yield* store.write(location, WRAP_HEAL_URI, content, {mode: 'create'});
+          yield* stageDeferredCodeAnchorIntent(config, {
+            memoryContent: content,
+            memoryMetadata: metadata,
+            memoryUri: WRAP_HEAL_URI,
+            request: {
+              callerCwd: sibling,
+              codeRefs: ['src/heal.ts'],
+              recovery: {
+                code: 'ready-graph-unavailable',
+                indexingStarted: false,
+                observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
+                preparation: {
+                  action: 'index-current-graph',
+                  arguments: [],
+                  command: 'threadnote graph index --no-vectors',
+                  target: 'callerCwd',
+                },
+                recovery: 'prepare-current-graph',
+                retryCondition: 'after-current-graph-ready',
+                retryable: true,
+                type: 'memory-code-citation-capture-recovery',
+                version: 1,
+              },
+            },
+          });
+          yield* fs.remove(sibling, {recursive: true});
+
+          const indexer = yield* CodeGraphIndexer;
+          yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: home}).pipe(TestClock.withLive);
+
+          expect(yield* hasDeferredCodeAnchorIntent(config, WRAP_HEAL_URI)).toBe(true);
+          expect(parseMemoryDocument(WRAP_HEAL_URI, yield* store.read(location, WRAP_HEAL_URI))).toMatchObject({
+            body,
+            metadata: {memoryId: metadata.memoryId, status: metadata.status},
+          });
+          expect(
+            parseMemoryDocument(WRAP_HEAL_URI, yield* store.read(location, WRAP_HEAL_URI))?.metadata.codeCitations
+              ?.length ?? 0,
+          ).toBe(0);
+
+          yield* refreshPendingDeferredCodeAnchorWorkspaces(config).pipe(
+            Effect.provideService(
+              DeferredCodeAnchorRefreshScheduler,
+              DeferredCodeAnchorRefreshScheduler.of({schedule: () => Effect.void}),
+            ),
+          );
+
+          expect(yield* hasDeferredCodeAnchorIntent(config, WRAP_HEAL_URI)).toBe(false);
+          expect(
+            parseMemoryDocument(WRAP_HEAL_URI, yield* store.read(location, WRAP_HEAL_URI))?.metadata.codeCitations
+              ?.length ?? 0,
+          ).toBe(0);
+          expect(yield* deferredCodeAnchorDoctorCheck(config)).toMatchObject({status: 'ok'});
         }),
       ).pipe(withTesterUser, provideTestLayer(ApplicationLayer)),
     60_000,

--- a/test/unit/deferred-code-anchor-index-heal.test.ts
+++ b/test/unit/deferred-code-anchor-index-heal.test.ts
@@ -106,119 +106,119 @@ describe('in-process graph-index deferred-anchor recovery', () => {
     });
   });
 
-  effectIt.effect('finalizes a matching intent after ApplicationLayer in-process index', () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-wrap-heal-'});
-        const repository = path.join(root, 'repository');
-        const home = path.join(root, 'home');
-        const manifestPath = path.join(home, 'seed-manifest.yaml');
-        yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
-        yield* fs.makeDirectory(home, {recursive: true});
-        yield* fs.writeFileString(path.join(repository, 'src', 'heal.ts'), 'export const wrapHeal = "ready";\n');
-        yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
-        yield* runCommandEffect('git', ['init', '--quiet'], {cwd: repository}).pipe(TestClock.withLive);
-        yield* runCommandEffect('git', ['add', '.'], {cwd: repository}).pipe(TestClock.withLive);
-        yield* runCommandEffect(
-          'git',
-          [
-            '-c',
-            'user.name=Threadnote Test',
-            '-c',
-            'user.email=test@threadnote.local',
-            'commit',
-            '--quiet',
-            '--message',
-            'fixture',
-          ],
-          {cwd: repository},
-        ).pipe(TestClock.withLive);
+  effectIt.effect(
+    'finalizes a matching intent after ApplicationLayer in-process index',
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-wrap-heal-'});
+          const repository = path.join(root, 'repository');
+          const home = path.join(root, 'home');
+          const manifestPath = path.join(home, 'seed-manifest.yaml');
+          yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
+          yield* fs.makeDirectory(home, {recursive: true});
+          yield* fs.writeFileString(path.join(repository, 'src', 'heal.ts'), 'export const wrapHeal = "ready";\n');
+          yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
+          yield* runCommandEffect('git', ['init', '--quiet'], {cwd: repository}).pipe(TestClock.withLive);
+          yield* runCommandEffect('git', ['add', '.'], {cwd: repository}).pipe(TestClock.withLive);
+          yield* runCommandEffect(
+            'git',
+            [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '--quiet',
+              '--message',
+              'fixture',
+            ],
+            {cwd: repository},
+          ).pipe(TestClock.withLive);
 
-        const config: RuntimeConfig = {
-          account: 'local',
-          agentContextHome: home,
-          agentId: 'threadnote',
-          manifestPath,
-          user: 'tester',
-        };
-        const metadata: MemoryMetadata = {
-          kind: 'durable',
-          memoryId: 'tn_wrap_heal',
-          project: 'threadnote',
-          schemaVersion: MEMORY_SCHEMA_VERSION,
-          sourceAgentClient: 'test',
-          status: 'active',
-          timestamp: '2026-09-10T00:00:00.000Z',
-          topic: 'wrap-heal',
-          visibility: 'personal',
-        };
-        const body = 'Wrap heal must cite after in-process index.';
-        const content = formatMemoryDocument('MEMORY', metadata, body);
-        const store = yield* ResourceStore;
-        const location = {account: config.account, home, user: config.user} as const;
-        yield* store.write(location, WRAP_HEAL_URI, content, {mode: 'create'});
-        yield* stageDeferredCodeAnchorIntent(config, {
-          memoryContent: content,
-          memoryMetadata: metadata,
-          memoryUri: WRAP_HEAL_URI,
-          request: {
-            callerCwd: repository,
-            codeRefs: ['src/heal.ts'],
-            recovery: {
-              code: 'ready-graph-unavailable',
-              indexingStarted: false,
-              observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
-              preparation: {
-                action: 'index-current-graph',
-                arguments: [],
-                command: 'threadnote graph index --no-vectors',
-                target: 'callerCwd',
+          const config: RuntimeConfig = {
+            account: 'local',
+            agentContextHome: home,
+            agentId: 'threadnote',
+            manifestPath,
+            user: 'tester',
+          };
+          const metadata: MemoryMetadata = {
+            kind: 'durable',
+            memoryId: 'tn_wrap_heal',
+            project: 'threadnote',
+            schemaVersion: MEMORY_SCHEMA_VERSION,
+            sourceAgentClient: 'test',
+            status: 'active',
+            timestamp: '2026-09-10T00:00:00.000Z',
+            topic: 'wrap-heal',
+            visibility: 'personal',
+          };
+          const body = 'Wrap heal must cite after in-process index.';
+          const content = formatMemoryDocument('MEMORY', metadata, body);
+          const store = yield* ResourceStore;
+          const location = {account: config.account, home, user: config.user} as const;
+          yield* store.write(location, WRAP_HEAL_URI, content, {mode: 'create'});
+          yield* stageDeferredCodeAnchorIntent(config, {
+            memoryContent: content,
+            memoryMetadata: metadata,
+            memoryUri: WRAP_HEAL_URI,
+            request: {
+              callerCwd: repository,
+              codeRefs: ['src/heal.ts'],
+              recovery: {
+                code: 'ready-graph-unavailable',
+                indexingStarted: false,
+                observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
+                preparation: {
+                  action: 'index-current-graph',
+                  arguments: [],
+                  command: 'threadnote graph index --no-vectors',
+                  target: 'callerCwd',
+                },
+                recovery: 'prepare-current-graph',
+                retryCondition: 'after-current-graph-ready',
+                retryable: true,
+                type: 'memory-code-citation-capture-recovery',
+                version: 1,
               },
-              recovery: 'prepare-current-graph',
-              retryCondition: 'after-current-graph-ready',
-              retryable: true,
-              type: 'memory-code-citation-capture-recovery',
-              version: 1,
             },
-          },
-        });
-        const pendingRoot = path.join(
-          home,
-          'data',
-          'local',
-          'user',
-          'tester',
-          'private',
-          'deferred-code-anchors',
-          'v1',
-        );
-        expect(
-          (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
-            isDeferredCodeAnchorIntentFilename(path.basename(name)),
-          ),
-        ).toHaveLength(1);
+          });
+          const pendingRoot = path.join(
+            home,
+            'data',
+            'local',
+            'user',
+            'tester',
+            'private',
+            'deferred-code-anchors',
+            'v1',
+          );
+          expect(
+            (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+              isDeferredCodeAnchorIntentFilename(path.basename(name)),
+            ),
+          ).toHaveLength(1);
 
-        const indexer = yield* CodeGraphIndexer;
-        yield* indexer
-          .index({cwd: repository, ensureVectors: false, threadnoteHome: home})
-          .pipe(TestClock.withLive);
+          const indexer = yield* CodeGraphIndexer;
+          yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: home}).pipe(TestClock.withLive);
 
-        expect(
-          (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
-            isDeferredCodeAnchorIntentFilename(path.basename(name)),
-          ),
-        ).toEqual([]);
-        const finalized = parseMemoryDocument(WRAP_HEAL_URI, yield* store.read(location, WRAP_HEAL_URI));
-        expect(finalized?.body).toBe(body);
-        expect(finalized?.metadata).toMatchObject({
-          codeCitations: [{path: 'src/heal.ts'}],
-          memoryId: metadata.memoryId,
-          status: metadata.status,
-        });
-      }),
-    ).pipe(withTesterUser, provideTestLayer(ApplicationLayer)),
+          expect(
+            (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+              isDeferredCodeAnchorIntentFilename(path.basename(name)),
+            ),
+          ).toEqual([]);
+          const finalized = parseMemoryDocument(WRAP_HEAL_URI, yield* store.read(location, WRAP_HEAL_URI));
+          expect(finalized?.body).toBe(body);
+          expect(finalized?.metadata).toMatchObject({
+            codeCitations: [{path: 'src/heal.ts'}],
+            memoryId: metadata.memoryId,
+            status: metadata.status,
+          });
+        }),
+      ).pipe(withTesterUser, provideTestLayer(ApplicationLayer)),
     60_000,
   );
 });

--- a/test/unit/deferred-code-anchor-index-heal.test.ts
+++ b/test/unit/deferred-code-anchor-index-heal.test.ts
@@ -1,0 +1,280 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {CodeGraphIndexer, type CodeGraphIndexerShape} from '../../src/code_graph/indexer.js';
+import type {CodeGraphIndexSummary} from '../../src/code_graph/types.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ResourceStore} from '../../src/effect/resource-store.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import {
+  isDeferredCodeAnchorIntentFilename,
+  stageDeferredCodeAnchorIntent,
+} from '../../src/memory/deferred_code_anchor.js';
+import {withDeferredCodeAnchorIndexHeal} from '../../src/memory/deferred_code_anchor_index_heal.js';
+import {formatMemoryDocument, parseMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {TestError} from '../helpers/test-error.js';
+
+const WRAP_HEAL_URI = 'threadnote://user/tester/memories/durable/projects/threadnote/wrap-heal.md';
+
+describe('in-process graph-index deferred-anchor recovery', () => {
+  effectIt.effect('heals matching intents after a successful in-process index', () => {
+    const summary = indexSummary();
+    const healed: Array<{readonly cwd: string; readonly home: string; readonly worktreeId: string}> = [];
+    const inner = indexer({
+      index: () => Effect.succeed(summary),
+    });
+
+    return Effect.gen(function* () {
+      const published = yield* withDeferredCodeAnchorIndexHeal(inner, (options, publishedSummary) =>
+        Effect.sync(() => {
+          healed.push({
+            cwd: options.cwd,
+            home: options.threadnoteHome,
+            worktreeId: publishedSummary.identity.worktreeId,
+          });
+        }),
+      ).index({
+        cwd: '/repo',
+        threadnoteHome: '/threadnote-home',
+      });
+
+      expect(published).toBe(summary);
+      expect(healed).toEqual([{cwd: '/repo', home: '/threadnote-home', worktreeId: summary.identity.worktreeId}]);
+    });
+  });
+
+  effectIt.effect('does not heal when index fails', () => {
+    const healed: string[] = [];
+    const inner = indexer({
+      index: () => Effect.fail(TestError.make({message: 'index failed'})),
+    });
+
+    return Effect.gen(function* () {
+      const failure = yield* withDeferredCodeAnchorIndexHeal(inner, () =>
+        Effect.sync(() => {
+          healed.push('healed');
+        }),
+      )
+        .index({cwd: '/repo', threadnoteHome: '/threadnote-home'})
+        .pipe(Effect.flip);
+
+      expect(failure).toMatchObject({message: 'index failed'});
+      expect(healed).toEqual([]);
+    });
+  });
+
+  effectIt.effect('keeps a successful index when heal fails closed', () => {
+    const summary = indexSummary();
+    const inner = indexer({
+      index: () => Effect.succeed(summary),
+    });
+
+    return Effect.gen(function* () {
+      expect(
+        yield* withDeferredCodeAnchorIndexHeal(inner, () =>
+          Effect.fail(TestError.make({message: 'heal failed'})).pipe(Effect.asVoid),
+        ).index({
+          cwd: '/repo',
+          threadnoteHome: '/threadnote-home',
+        }),
+      ).toBe(summary);
+    });
+  });
+
+  effectIt.effect('does not heal historical ensureCommit publication', () => {
+    const healed: string[] = [];
+    const inner = indexer({
+      ensureCommit: () => Effect.succeed({leaseToken: 'lease', snapshot: indexSummary().snapshot}),
+    });
+
+    return Effect.gen(function* () {
+      yield* withDeferredCodeAnchorIndexHeal(inner, () =>
+        Effect.sync(() => {
+          healed.push('healed');
+        }),
+      ).ensureCommit({
+        commit: 'b'.repeat(40),
+        cwd: '/repo',
+        threadnoteHome: '/threadnote-home',
+      });
+      expect(healed).toEqual([]);
+    });
+  });
+
+  effectIt.effect('finalizes a matching intent after ApplicationLayer in-process index', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-wrap-heal-'});
+        const repository = path.join(root, 'repository');
+        const home = path.join(root, 'home');
+        const manifestPath = path.join(home, 'seed-manifest.yaml');
+        yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
+        yield* fs.makeDirectory(home, {recursive: true});
+        yield* fs.writeFileString(path.join(repository, 'src', 'heal.ts'), 'export const wrapHeal = "ready";\n');
+        yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
+        yield* runCommandEffect('git', ['init', '--quiet'], {cwd: repository}).pipe(TestClock.withLive);
+        yield* runCommandEffect('git', ['add', '.'], {cwd: repository}).pipe(TestClock.withLive);
+        yield* runCommandEffect(
+          'git',
+          [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '--quiet',
+            '--message',
+            'fixture',
+          ],
+          {cwd: repository},
+        ).pipe(TestClock.withLive);
+
+        const config: RuntimeConfig = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'threadnote',
+          manifestPath,
+          user: 'tester',
+        };
+        const metadata: MemoryMetadata = {
+          kind: 'durable',
+          memoryId: 'tn_wrap_heal',
+          project: 'threadnote',
+          schemaVersion: MEMORY_SCHEMA_VERSION,
+          sourceAgentClient: 'test',
+          status: 'active',
+          timestamp: '2026-09-10T00:00:00.000Z',
+          topic: 'wrap-heal',
+          visibility: 'personal',
+        };
+        const body = 'Wrap heal must cite after in-process index.';
+        const content = formatMemoryDocument('MEMORY', metadata, body);
+        const store = yield* ResourceStore;
+        const location = {account: config.account, home, user: config.user} as const;
+        yield* store.write(location, WRAP_HEAL_URI, content, {mode: 'create'});
+        yield* stageDeferredCodeAnchorIntent(config, {
+          memoryContent: content,
+          memoryMetadata: metadata,
+          memoryUri: WRAP_HEAL_URI,
+          request: {
+            callerCwd: repository,
+            codeRefs: ['src/heal.ts'],
+            recovery: {
+              code: 'ready-graph-unavailable',
+              indexingStarted: false,
+              observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
+              preparation: {
+                action: 'index-current-graph',
+                arguments: [],
+                command: 'threadnote graph index --no-vectors',
+                target: 'callerCwd',
+              },
+              recovery: 'prepare-current-graph',
+              retryCondition: 'after-current-graph-ready',
+              retryable: true,
+              type: 'memory-code-citation-capture-recovery',
+              version: 1,
+            },
+          },
+        });
+        const pendingRoot = path.join(
+          home,
+          'data',
+          'local',
+          'user',
+          'tester',
+          'private',
+          'deferred-code-anchors',
+          'v1',
+        );
+        expect(
+          (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+            isDeferredCodeAnchorIntentFilename(path.basename(name)),
+          ),
+        ).toHaveLength(1);
+
+        const indexer = yield* CodeGraphIndexer;
+        yield* indexer
+          .index({cwd: repository, ensureVectors: false, threadnoteHome: home})
+          .pipe(TestClock.withLive);
+
+        expect(
+          (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+            isDeferredCodeAnchorIntentFilename(path.basename(name)),
+          ),
+        ).toEqual([]);
+        const finalized = parseMemoryDocument(WRAP_HEAL_URI, yield* store.read(location, WRAP_HEAL_URI));
+        expect(finalized?.body).toBe(body);
+        expect(finalized?.metadata).toMatchObject({
+          codeCitations: [{path: 'src/heal.ts'}],
+          memoryId: metadata.memoryId,
+          status: metadata.status,
+        });
+      }),
+    ).pipe(withTesterUser, provideTestLayer(ApplicationLayer)),
+    60_000,
+  );
+});
+
+function withTesterUser<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    return yield* effect.pipe(
+      Effect.provideService(
+        SystemInfo,
+        SystemInfo.of({
+          ...system,
+          environment: () => ({...system.environment(), THREADNOTE_USER: 'tester'}),
+        }),
+      ),
+    );
+  });
+}
+
+function indexer(overrides: Partial<CodeGraphIndexerShape>): CodeGraphIndexerShape {
+  return {
+    ensureCommit: () => Effect.die(TestError.make({message: 'unexpected ensureCommit'})),
+    index: () => Effect.die(TestError.make({message: 'unexpected index'})),
+    ...overrides,
+  };
+}
+
+function indexSummary(): CodeGraphIndexSummary {
+  return {
+    diagnostics: [],
+    durationMs: 1,
+    identity: {
+      caseMode: 'sensitive',
+      checkoutId: 'a'.repeat(64),
+      displayName: 'fixture',
+      gitCommonDirectory: '/repo/.git',
+      headCommit: 'b'.repeat(40),
+      objectFormat: 'sha1',
+      repoRoot: '/repo',
+      repositoryId: 'c'.repeat(64),
+      worktreeId: 'd'.repeat(64),
+    },
+    reusedFiles: 0,
+    skippedFiles: 0,
+    snapshot: {
+      commit: 'b'.repeat(40),
+      completedAt: '2026-09-10T00:00:00.000Z',
+      dirty: false,
+      edgeCount: 0,
+      extractorSet: 'e'.repeat(64),
+      fileCount: 1,
+      id: `cgsn_${'1'.repeat(40)}`,
+      repositoryId: 'c'.repeat(64),
+      state: 'ready',
+      symbolCount: 1,
+      worktreeId: 'd'.repeat(64),
+    },
+  };
+}

--- a/test/unit/deferred-code-anchor-refresh.test.ts
+++ b/test/unit/deferred-code-anchor-refresh.test.ts
@@ -4,9 +4,12 @@ import {TestClock} from 'effect/testing';
 import {describe, expect} from 'vitest';
 import {CodeGraphWatcher} from '../../src/code_graph/watcher.js';
 import {runCommandEffect} from '../../src/effect/command.js';
+import {ResourceStore} from '../../src/effect/resource-store.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
 import {
+  deferredCodeAnchorDoctorCheck,
+  hasDeferredCodeAnchorIntent,
   stageDeferredCodeAnchorIntent,
   type DeferredCodeAnchorWriteRequest,
 } from '../../src/memory/deferred_code_anchor.js';
@@ -17,7 +20,7 @@ import {
   refreshPendingDeferredCodeAnchorWorkspaces,
   scheduleDeferredCodeAnchorWorkspaceRefresh,
 } from '../../src/memory/deferred_code_anchor_refresh.js';
-import {formatMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
+import {formatMemoryDocument, parseMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 
@@ -53,6 +56,58 @@ describe('deferred code-anchor workspace refresh', () => {
           }),
         ]);
         expect(targets.some(target => target.cwd === fixture.missing)).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('discards missing-cwd intents during workspace refresh without citing another checkout', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeRefreshFixture();
+        const presentContent = memoryContent(fixture.metadata, 'Present workspace.');
+        const missingMetadata = {...fixture.metadata, memoryId: 'tn_missing', topic: 'missing'};
+        const missingContent = memoryContent(missingMetadata, 'Deleted workspace.');
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: presentContent,
+          memoryMetadata: fixture.metadata,
+          memoryUri: PRESENT_URI,
+          request: deferredRequest(fixture.present),
+        });
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: missingContent,
+          memoryMetadata: missingMetadata,
+          memoryUri: MISSING_URI,
+          request: deferredRequest(fixture.missing),
+        });
+        const store = yield* ResourceStore;
+        const location = {
+          account: fixture.config.account,
+          home: fixture.config.agentContextHome,
+          user: fixture.config.user,
+        } as const;
+        yield* store.write(location, PRESENT_URI, presentContent, {mode: 'create'});
+        yield* store.write(location, MISSING_URI, missingContent, {mode: 'create'});
+        yield* fixture.fs.remove(fixture.missing, {recursive: true});
+
+        yield* refreshPendingDeferredCodeAnchorWorkspaces(fixture.config).pipe(
+          Effect.provideService(
+            DeferredCodeAnchorRefreshScheduler,
+            DeferredCodeAnchorRefreshScheduler.of({
+              schedule: () => Effect.void,
+            }),
+          ),
+        );
+
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, PRESENT_URI)).toBe(true);
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MISSING_URI)).toBe(false);
+        expect(
+          parseMemoryDocument(MISSING_URI, yield* store.read(location, MISSING_URI))?.metadata.codeCitations?.length ??
+            0,
+        ).toBe(0);
+        expect(yield* deferredCodeAnchorDoctorCheck(fixture.config)).toMatchObject({
+          detail: '1 private code-anchor intent(s) are pending finalization',
+          status: 'warn',
+        });
       }),
     ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );

--- a/test/unit/deferred-code-anchor-refresh.test.ts
+++ b/test/unit/deferred-code-anchor-refresh.test.ts
@@ -1,0 +1,231 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {CodeGraphWatcher} from '../../src/code_graph/watcher.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import {
+  stageDeferredCodeAnchorIntent,
+  type DeferredCodeAnchorWriteRequest,
+} from '../../src/memory/deferred_code_anchor.js';
+import {
+  DeferredCodeAnchorRefreshScheduler,
+  deferredCodeAnchorRefreshSchedulerLayer,
+  listDeferredCodeAnchorWorkspaceRefreshTargets,
+  refreshPendingDeferredCodeAnchorWorkspaces,
+  scheduleDeferredCodeAnchorWorkspaceRefresh,
+} from '../../src/memory/deferred_code_anchor_refresh.js';
+import {formatMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const PRESENT_URI = 'threadnote://user/tester/memories/durable/projects/threadnote/present.md';
+const MISSING_URI = 'threadnote://user/tester/memories/durable/projects/threadnote/missing.md';
+
+describe('deferred code-anchor workspace refresh', () => {
+  effectIt.effect('lists still-present matching worktrees and skips a deleted checkout', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeRefreshFixture();
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: memoryContent(fixture.metadata, 'Present workspace.'),
+          memoryMetadata: {...fixture.metadata, memoryId: 'tn_present', topic: 'present'},
+          memoryUri: PRESENT_URI,
+          request: deferredRequest(fixture.present),
+        });
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: memoryContent(
+            {...fixture.metadata, memoryId: 'tn_missing', topic: 'missing'},
+            'Deleted workspace.',
+          ),
+          memoryMetadata: {...fixture.metadata, memoryId: 'tn_missing', topic: 'missing'},
+          memoryUri: MISSING_URI,
+          request: deferredRequest(fixture.missing),
+        });
+        yield* fixture.fs.remove(fixture.missing, {recursive: true});
+
+        const targets = yield* listDeferredCodeAnchorWorkspaceRefreshTargets(fixture.config);
+        expect(targets).toEqual([
+          expect.objectContaining({
+            cwd: fixture.present,
+          }),
+        ]);
+        expect(targets.some(target => target.cwd === fixture.missing)).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('schedules only still-present matching worktrees', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeRefreshFixture();
+        const scheduled: {readonly cwd: string; readonly key: string; readonly threadnoteHome: string}[] = [];
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: memoryContent(fixture.metadata, 'Present workspace.'),
+          memoryMetadata: {...fixture.metadata, memoryId: 'tn_present', topic: 'present'},
+          memoryUri: PRESENT_URI,
+          request: deferredRequest(fixture.present),
+        });
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: memoryContent(
+            {...fixture.metadata, memoryId: 'tn_missing', topic: 'missing'},
+            'Deleted workspace.',
+          ),
+          memoryMetadata: {...fixture.metadata, memoryId: 'tn_missing', topic: 'missing'},
+          memoryUri: MISSING_URI,
+          request: deferredRequest(fixture.missing),
+        });
+        yield* fixture.fs.remove(fixture.missing, {recursive: true});
+
+        yield* refreshPendingDeferredCodeAnchorWorkspaces(fixture.config).pipe(
+          Effect.provideService(
+            DeferredCodeAnchorRefreshScheduler,
+            DeferredCodeAnchorRefreshScheduler.of({
+              schedule: options => Effect.sync(() => scheduled.push(options)),
+            }),
+          ),
+        );
+
+        expect(scheduled).toEqual([
+          {
+            cwd: fixture.present,
+            key: (yield* listDeferredCodeAnchorWorkspaceRefreshTargets(fixture.config))[0]?.worktreeId,
+            threadnoteHome: fixture.config.agentContextHome,
+          },
+        ]);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('schedules still-present worktrees as background builder admission', () =>
+    Effect.gen(function* () {
+      const scheduled: Array<{readonly admissionClass?: string; readonly cwd: string}> = [];
+      yield* scheduleDeferredCodeAnchorWorkspaceRefresh(
+        {agentContextHome: '/threadnote-home'},
+        {cwd: '/repo', worktreeId: 'a'.repeat(64)},
+      ).pipe(
+        provideTestLayer(
+          deferredCodeAnchorRefreshSchedulerLayer.pipe(
+            Layer.provide(
+              Layer.succeed(
+                CodeGraphWatcher,
+                CodeGraphWatcher.of({
+                  ensure: () => Effect.void,
+                  metrics: Effect.succeed({
+                    activeRefreshKeys: 0,
+                    activeWatches: 0,
+                    executingRefreshes: 0,
+                    executingRefreshHighWater: 0,
+                    idleSweepFibers: 0,
+                    maximumWatchers: 0,
+                    pendingTrailingRefreshes: 0,
+                    retainedStatuses: 0,
+                  }),
+                  refresh: options =>
+                    Effect.sync(() => {
+                      scheduled.push({admissionClass: options.admissionClass, cwd: options.cwd});
+                      return true;
+                    }),
+                  status: () => Effect.succeedNone,
+                  watch: () => Effect.void,
+                }),
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(scheduled).toEqual([{admissionClass: 'background', cwd: '/repo'}]);
+    }),
+  );
+
+  effectIt.effect('does not schedule when the refresh scheduler is absent', () =>
+    Effect.gen(function* () {
+      const scheduled: string[] = [];
+      yield* scheduleDeferredCodeAnchorWorkspaceRefresh(
+        {agentContextHome: '/threadnote-home'},
+        {cwd: '/repo', worktreeId: 'a'.repeat(64)},
+      );
+      expect(scheduled).toEqual([]);
+    }),
+  );
+});
+
+const makeRefreshFixture = Effect.fn('deferredCodeAnchorRefreshTest.makeFixture')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-deferred-anchor-refresh-'});
+  const present = path.join(home, 'present');
+  const missing = path.join(home, 'missing');
+  yield* Effect.forEach([present, missing], cwd => initializeGitCheckout(cwd), {concurrency: 1});
+  const manifestPath = path.join(home, 'seed-manifest.yaml');
+  yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
+  const config: RuntimeConfig = {
+    account: 'local',
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath,
+    user: 'tester',
+  };
+  const metadata: MemoryMetadata = {
+    kind: 'durable',
+    memoryId: 'tn_present',
+    project: 'threadnote',
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    sourceAgentClient: 'test',
+    status: 'active',
+    timestamp: '2026-09-10T00:00:00.000Z',
+    topic: 'present',
+    visibility: 'personal',
+  };
+  return {config, fs, metadata, missing, path, present};
+});
+
+const initializeGitCheckout = Effect.fn('deferredCodeAnchorRefreshTest.initGit')(function* (cwd: string) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.makeDirectory(cwd);
+  yield* runCommandEffect('git', ['init', '--quiet'], {cwd});
+  yield* runCommandEffect(
+    'git',
+    [
+      '-c',
+      'user.name=Threadnote Test',
+      '-c',
+      'user.email=test@threadnote.local',
+      'commit',
+      '--allow-empty',
+      '--quiet',
+      '--message',
+      'fixture',
+    ],
+    {cwd},
+  );
+});
+
+function deferredRequest(callerCwd: string): DeferredCodeAnchorWriteRequest {
+  return {
+    callerCwd,
+    codeRefs: ['src/index.ts'],
+    recovery: {
+      code: 'ready-graph-unavailable',
+      indexingStarted: false,
+      observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
+      preparation: {
+        action: 'index-current-graph',
+        arguments: [],
+        command: 'threadnote graph index --no-vectors',
+        target: 'callerCwd',
+      },
+      recovery: 'prepare-current-graph',
+      retryCondition: 'after-current-graph-ready',
+      retryable: true,
+      type: 'memory-code-citation-capture-recovery',
+      version: 1,
+    },
+  };
+}
+
+function memoryContent(metadata: MemoryMetadata, body: string): string {
+  return formatMemoryDocument('MEMORY', metadata, body);
+}

--- a/test/unit/deferred-code-anchor.property.test.ts
+++ b/test/unit/deferred-code-anchor.property.test.ts
@@ -11,6 +11,7 @@ import {
   type DeferredCodeAnchorIntentV1,
   type DeferredMemoryObservation,
 } from '../../src/memory/deferred_code_anchor.js';
+import {selectDeferredCodeAnchorWorkspaceRefreshTargets} from '../../src/memory/deferred_code_anchor_refresh.js';
 
 const URI = 'threadnote://user/test/memories/durable/projects/threadnote/deferred.md';
 
@@ -128,10 +129,100 @@ describe('deferred code-anchor state model', () => {
         );
       }),
   );
+
+  effectIt.effect.prop(
+    'refresh targets stay on still-present matching worktrees and never rebind a sibling checkout',
+    {
+      duplicateWorktree: fc.boolean(),
+      intents: fc.uniqueArray(
+        fc.record({
+          cwdIndex: fc.integer({min: 0, max: 2}),
+          identity: fc.constantFrom('match', 'missing', 'mismatch'),
+          workset: fc.boolean(),
+        }),
+        {maxLength: 3, selector: item => item.cwdIndex},
+      ),
+      siblingPresent: fc.boolean(),
+    },
+    input =>
+      Effect.sync(() => {
+        const cwds = ['/repo-a', '/repo-b', '/repo-missing'] as const;
+        const intents = input.intents.map((item, index) =>
+          deferredIntent({
+            callerCwd: cwds[item.cwdIndex],
+            memoryUri: `${URI}-${index}`,
+            preparation: item.workset ? 'workset' : 'caller',
+            repositoryId: '1'.repeat(64),
+            worktreeId: `${item.cwdIndex + 2}`.repeat(64),
+          }),
+        );
+        const match = intents.find((_, index) => {
+          const item = input.intents[index];
+          return item !== undefined && !item.workset && item.identity === 'match';
+        });
+        if (input.duplicateWorktree && match !== undefined) {
+          intents.push(
+            deferredIntent({
+              callerCwd: match.callerCwd,
+              memoryUri: `${URI}-duplicate`,
+              repositoryId: match.repositoryId,
+              worktreeId: match.worktreeId,
+            }),
+          );
+        }
+        const identityByCwd = new Map<string, {repositoryId: string; worktreeId: string} | undefined>();
+        for (const [index, item] of input.intents.entries()) {
+          const intent = intents[index];
+          if (intent === undefined) continue;
+          if (item.identity === 'missing') {
+            identityByCwd.set(intent.callerCwd, undefined);
+            continue;
+          }
+          identityByCwd.set(
+            intent.callerCwd,
+            item.identity === 'mismatch'
+              ? {repositoryId: intent.repositoryId, worktreeId: '9'.repeat(64)}
+              : {repositoryId: intent.repositoryId, worktreeId: intent.worktreeId},
+          );
+        }
+        if (input.siblingPresent) {
+          identityByCwd.set('/repo-sibling', {repositoryId: '1'.repeat(64), worktreeId: '5'.repeat(64)});
+        }
+        const targets = selectDeferredCodeAnchorWorkspaceRefreshTargets(intents, identityByCwd);
+        const expectedCwds = new Set(
+          intents
+            .filter((intent, index) => {
+              const item = input.intents[index];
+              return item !== undefined && !item.workset && item.identity === 'match';
+            })
+            .map(intent => intent.callerCwd),
+        );
+        expect(new Set(targets.map(target => target.cwd))).toEqual(expectedCwds);
+        expect(new Set(targets.map(target => target.worktreeId)).size).toBe(targets.length);
+        expect(targets.some(target => target.cwd === '/repo-sibling')).toBe(false);
+        expect(targets.some(target => target.cwd === '/repo-missing' && !expectedCwds.has('/repo-missing'))).toBe(
+          false,
+        );
+        for (const target of targets) {
+          const intent = intents.find(candidate => candidate.callerCwd === target.cwd);
+          expect(intent).toBeDefined();
+          expect(intent?.recovery.preparation.target).toBe('callerCwd');
+          expect(target.repositoryId).toBe(intent?.repositoryId);
+          expect(target.worktreeId).toBe(intent?.worktreeId);
+        }
+      }),
+  );
 });
 
 function deferredIntent(
-  options: {readonly codeRefs?: readonly string[]; readonly preparation?: 'caller' | 'workset'} = {},
+  options: {
+    readonly callerCwd?: string;
+    readonly codeRefs?: readonly string[];
+    readonly memoryUri?: string;
+    readonly preparation?: 'caller' | 'workset';
+    readonly repositoryId?: string;
+    readonly worktreeId?: string;
+  } = {},
 ): DeferredCodeAnchorIntentV1 {
   const preparation =
     options.preparation === 'workset'
@@ -149,13 +240,13 @@ function deferredIntent(
         };
   return {
     authorization: 'explicit-code-refs',
-    callerCwd: '/repo',
+    callerCwd: options.callerCwd ?? '/repo',
     codeRefs: options.codeRefs ?? ['src/index.ts'],
     createdAt: '2026-08-29T00:00:00.000Z',
     expectedMemoryHash: 'expected-hash',
     intentId: 'tnca_test',
     memoryId: 'tn_memory',
-    memoryUri: URI,
+    memoryUri: options.memoryUri ?? URI,
     recovery: {
       code: 'exact-current-evidence-unavailable',
       indexingStarted: false,
@@ -167,11 +258,11 @@ function deferredIntent(
       type: 'memory-code-citation-capture-recovery',
       version: 1,
     },
-    repositoryId: '1'.repeat(64),
+    repositoryId: options.repositoryId ?? '1'.repeat(64),
     type: 'threadnote-deferred-code-anchor-intent',
     version: 1,
     visibility: 'private-local',
-    worktreeId: '2'.repeat(64),
+    worktreeId: options.worktreeId ?? '2'.repeat(64),
   };
 }
 

--- a/test/unit/deferred-code-anchor.property.test.ts
+++ b/test/unit/deferred-code-anchor.property.test.ts
@@ -11,7 +11,10 @@ import {
   type DeferredCodeAnchorIntentV1,
   type DeferredMemoryObservation,
 } from '../../src/memory/deferred_code_anchor.js';
-import {selectDeferredCodeAnchorWorkspaceRefreshTargets} from '../../src/memory/deferred_code_anchor_refresh.js';
+import {
+  selectDeferredCodeAnchorMissingCheckoutIntents,
+  selectDeferredCodeAnchorWorkspaceRefreshTargets,
+} from '../../src/memory/deferred_code_anchor_refresh.js';
 
 const URI = 'threadnote://user/test/memories/durable/projects/threadnote/deferred.md';
 
@@ -170,25 +173,35 @@ describe('deferred code-anchor state model', () => {
             }),
           );
         }
-        const identityByCwd = new Map<string, {repositoryId: string; worktreeId: string} | undefined>();
+        const identityByCwd = new Map<
+          string,
+          | {readonly state: 'missing'}
+          | {readonly state: 'unobserved'}
+          | {readonly state: 'present'; readonly repositoryId: string; readonly worktreeId: string}
+        >();
         for (const [index, item] of input.intents.entries()) {
           const intent = intents[index];
           if (intent === undefined) continue;
           if (item.identity === 'missing') {
-            identityByCwd.set(intent.callerCwd, undefined);
+            identityByCwd.set(intent.callerCwd, {state: 'missing'});
             continue;
           }
           identityByCwd.set(
             intent.callerCwd,
             item.identity === 'mismatch'
-              ? {repositoryId: intent.repositoryId, worktreeId: '9'.repeat(64)}
-              : {repositoryId: intent.repositoryId, worktreeId: intent.worktreeId},
+              ? {state: 'present', repositoryId: intent.repositoryId, worktreeId: '9'.repeat(64)}
+              : {state: 'present', repositoryId: intent.repositoryId, worktreeId: intent.worktreeId},
           );
         }
         if (input.siblingPresent) {
-          identityByCwd.set('/repo-sibling', {repositoryId: '1'.repeat(64), worktreeId: '5'.repeat(64)});
+          identityByCwd.set('/repo-sibling', {
+            state: 'present',
+            repositoryId: '1'.repeat(64),
+            worktreeId: '5'.repeat(64),
+          });
         }
         const targets = selectDeferredCodeAnchorWorkspaceRefreshTargets(intents, identityByCwd);
+        const discarded = selectDeferredCodeAnchorMissingCheckoutIntents(intents, identityByCwd);
         const expectedCwds = new Set(
           intents
             .filter((intent, index) => {
@@ -203,6 +216,26 @@ describe('deferred code-anchor state model', () => {
         expect(targets.some(target => target.cwd === '/repo-missing' && !expectedCwds.has('/repo-missing'))).toBe(
           false,
         );
+        expect(discarded.map(intent => intent.memoryUri).sort()).toEqual(
+          intents
+            .filter(intent => identityByCwd.get(intent.callerCwd)?.state === 'missing')
+            .map(intent => intent.memoryUri)
+            .sort(),
+        );
+        expect(
+          discarded.some(intent => {
+            const observation = identityByCwd.get(intent.callerCwd);
+            return observation?.state === 'present';
+          }),
+        ).toBe(false);
+        for (const discardedIntent of discarded) {
+          expect(targets.some(target => target.cwd === discardedIntent.callerCwd)).toBe(false);
+          expect(
+            targets.some(
+              target => target.worktreeId === discardedIntent.worktreeId && target.cwd !== discardedIntent.callerCwd,
+            ),
+          ).toBe(false);
+        }
         for (const target of targets) {
           const intent = intents.find(candidate => candidate.callerCwd === target.cwd);
           expect(intent).toBeDefined();

--- a/test/unit/deferred-code-anchor.test.ts
+++ b/test/unit/deferred-code-anchor.test.ts
@@ -2,11 +2,12 @@ import {it as effectIt} from '@effect/vitest';
 import {Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {describe, expect} from 'vitest';
+import {codeGraphCommittedFileContentHash} from '../../src/code_graph/content_identity.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import type {CodeGraphStoreShape} from '../../src/code_graph/store_shape.js';
-import type {CodeGraphStatus} from '../../src/code_graph/types.js';
+import type {CodeGraphInventoryFile, CodeGraphStatus} from '../../src/code_graph/types.js';
 import {runCommandEffect} from '../../src/effect/command.js';
 import {sha256Hex} from '../../src/effect/digest.js';
 import {ResourceIoFailed, ResourceStore} from '../../src/effect/resource-store.js';
@@ -1152,6 +1153,224 @@ describe('deferred code-anchor outbox', () => {
     ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
+  effectIt.effect('discards a missing caller checkout without rebinding or citing the memory', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeFixture();
+        const content = memoryContent(fixture.metadata, 'Pending deleted worktree revision.');
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: content,
+          memoryMetadata: fixture.metadata,
+          memoryUri: MEMORY_URI,
+          request: deferredRequest(fixture.repository, ['src/deleted-worktree.ts']),
+        });
+        const store = yield* ResourceStore;
+        yield* store.write(resourceStoreLocation(fixture.config), MEMORY_URI, content, {mode: 'create'});
+        const [intentPath] = yield* fixtureIntentPaths(fixture);
+        const intent = JSON.parse(yield* fixture.fs.readFileString(intentPath)) as {
+          repositoryId: string;
+          worktreeId: string;
+        };
+        yield* fixture.fs.remove(fixture.repository, {recursive: true});
+
+        expect(
+          yield* finalizeDeferredCodeAnchorsForRoute(fixture.config, {
+            callerCwd: fixture.repository,
+            kind: 'repository',
+            repositoryId: intent.repositoryId,
+            worktreeId: 'c'.repeat(64),
+          }),
+        ).toMatchObject({matchedCount: 0, scannedCount: 0, state: 'completed'});
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(true);
+        expect(yield* deferredCodeAnchorDoctorCheck(fixture.config)).toMatchObject({status: 'warn'});
+
+        const receipt = yield* finalizeDeferredCodeAnchors(fixture.config);
+        expect(receipt).toMatchObject({
+          conflictCount: 1,
+          failedCount: 0,
+          pendingCount: 0,
+          items: [
+            {
+              memoryUri: MEMORY_URI,
+              reason: 'caller-checkout-missing',
+              state: 'conflict',
+            },
+          ],
+        });
+        expect(JSON.stringify(receipt)).not.toContain('src/deleted-worktree.ts');
+        expect(JSON.stringify(receipt)).not.toContain(fixture.repository);
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(false);
+        const deleted = parseMemoryDocument(
+          MEMORY_URI,
+          yield* store.read(resourceStoreLocation(fixture.config), MEMORY_URI),
+        );
+        expect(deleted).toMatchObject({
+          body: 'Pending deleted worktree revision.',
+          metadata: {memoryId: fixture.metadata.memoryId, status: 'active'},
+        });
+        expect(deleted?.metadata.codeCitations?.length ?? 0).toBe(0);
+        expect(yield* deferredCodeAnchorDoctorCheck(fixture.config)).toMatchObject({
+          detail: 'no pending private code-anchor intents',
+          status: 'ok',
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('discards a present checkout whose repository identity changed, not as a deleted cwd', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeFixture();
+        const content = memoryContent(fixture.metadata, 'Pending identity-mismatch revision.');
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: content,
+          memoryMetadata: fixture.metadata,
+          memoryUri: MEMORY_URI,
+          request: deferredRequest(fixture.repository, ['src/identity-changed.ts']),
+        });
+        const store = yield* ResourceStore;
+        yield* store.write(resourceStoreLocation(fixture.config), MEMORY_URI, content, {mode: 'create'});
+        const originalQuery = yield* CodeGraphQueryService;
+        const observed = yield* originalQuery.status(fixture.config.agentContextHome, fixture.repository, {
+          observeWorktree: true,
+          requestMaintenance: false,
+        });
+        const mismatchedQuery = CodeGraphQueryService.of({
+          ...originalQuery,
+          status: () =>
+            Effect.succeed({
+              ...observed,
+              identity: {...observed.identity, worktreeId: 'f'.repeat(64)},
+            }),
+        });
+
+        const receipt = yield* finalizeDeferredCodeAnchors(fixture.config).pipe(
+          Effect.provideService(CodeGraphQueryService, mismatchedQuery),
+        );
+        expect(receipt).toMatchObject({
+          conflictCount: 1,
+          failedCount: 0,
+          pendingCount: 0,
+          items: [
+            {
+              memoryUri: MEMORY_URI,
+              reason: 'caller-repository-identity-changed',
+              state: 'conflict',
+            },
+          ],
+        });
+        expect(receipt.items[0]?.reason).not.toBe('caller-checkout-missing');
+        expect(yield* fixture.fs.exists(fixture.repository)).toBe(true);
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(false);
+        expect(
+          parseMemoryDocument(MEMORY_URI, yield* store.read(resourceStoreLocation(fixture.config), MEMORY_URI))
+            ?.metadata.codeCitations?.length ?? 0,
+        ).toBe(0);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('keeps a retryable exact-current-graph gap pending instead of discarding it', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeFixture();
+        const content = memoryContent(fixture.metadata, 'Pending graph-readiness revision.');
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: content,
+          memoryMetadata: fixture.metadata,
+          memoryUri: MEMORY_URI,
+          request: deferredRequest(fixture.repository, ['src/pending-index.ts']),
+        });
+        const store = yield* ResourceStore;
+        yield* store.write(resourceStoreLocation(fixture.config), MEMORY_URI, content, {mode: 'create'});
+        const originalQuery = yield* CodeGraphQueryService;
+        const observed = yield* originalQuery.status(fixture.config.agentContextHome, fixture.repository, {
+          observeWorktree: true,
+          requestMaintenance: false,
+        });
+        const unreadinessQuery = CodeGraphQueryService.of({
+          ...originalQuery,
+          status: () =>
+            Effect.succeed({
+              ...observed,
+              freshness: 'stale' as const,
+              readySnapshot: undefined,
+              stale: true,
+            }),
+        });
+
+        const receipt = yield* finalizeDeferredCodeAnchors(fixture.config).pipe(
+          Effect.provideService(CodeGraphQueryService, unreadinessQuery),
+        );
+        expect(receipt).toMatchObject({
+          conflictCount: 0,
+          pendingCount: 1,
+          items: [
+            {
+              memoryUri: MEMORY_URI,
+              recoveryAction: 'prepare-current-graph',
+              retryable: true,
+              state: 'pending',
+            },
+          ],
+        });
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(true);
+        expect(yield* deferredCodeAnchorDoctorCheck(fixture.config)).toMatchObject({status: 'warn'});
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('finalizes the still-present exact-current subset and discards the unresolved remainder', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeFixture();
+        const presentPath = 'src/present.ts';
+        const missingPath = 'src/deleted-feature.ts';
+        const source = 'export const present = true;\n';
+        yield* fixture.fs.makeDirectory(fixture.path.join(fixture.repository, 'src'), {recursive: true});
+        yield* fixture.fs.writeFileString(fixture.path.join(fixture.repository, presentPath), source);
+        const content = memoryContent(fixture.metadata, 'Pending subset revision.');
+        yield* stageDeferredCodeAnchorIntent(fixture.config, {
+          memoryContent: content,
+          memoryMetadata: fixture.metadata,
+          memoryUri: MEMORY_URI,
+          request: deferredRequest(fixture.repository, [presentPath, missingPath]),
+        });
+        const store = yield* ResourceStore;
+        yield* store.write(resourceStoreLocation(fixture.config), MEMORY_URI, content, {mode: 'create'});
+        const graph = yield* exactCurrentCitationGraph(fixture, [
+          inventoryFile(presentPath, source, fixture.path.join(fixture.repository, presentPath)),
+        ]);
+
+        const receipt = yield* finalizeDeferredCodeAnchors(fixture.config).pipe(
+          Effect.provideService(CodeGraphQueryService, graph.query),
+          Effect.provideService(CodeGraphStore, graph.store),
+        );
+        expect(receipt).toMatchObject({
+          conflictCount: 0,
+          failedCount: 0,
+          finalizedCount: 1,
+          pendingCount: 0,
+          items: [{citationCount: 1, memoryUri: MEMORY_URI, state: 'finalized'}],
+        });
+        expect(JSON.stringify(receipt)).not.toContain(missingPath);
+        expect(JSON.stringify(receipt)).not.toContain(fixture.repository);
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(false);
+        expect(
+          parseMemoryDocument(MEMORY_URI, yield* store.read(resourceStoreLocation(fixture.config), MEMORY_URI)),
+        ).toMatchObject({
+          body: 'Pending subset revision.',
+          metadata: {
+            codeCitations: [expect.objectContaining({path: presentPath, target: {kind: 'file'}})],
+            memoryId: fixture.metadata.memoryId,
+            status: 'active',
+          },
+        });
+        expect(yield* deferredCodeAnchorDoctorCheck(fixture.config)).toMatchObject({status: 'ok'});
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
   effectIt.effect('classifies exact-graph locator misses with privacy-safe correction guidance', () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -1166,73 +1385,34 @@ describe('deferred code-anchor outbox', () => {
         });
         const store = yield* ResourceStore;
         yield* store.write(resourceStoreLocation(fixture.config), MEMORY_URI, content, {mode: 'create'});
-
-        const originalQuery = yield* CodeGraphQueryService;
-        const observed = yield* originalQuery.status(fixture.config.agentContextHome, fixture.repository, {
-          observeWorktree: true,
-          requestMaintenance: false,
-        });
-        const exactStatus: CodeGraphStatus = {
-          ...observed,
-          freshness: 'current',
-          readySnapshot: {
-            commit: observed.identity.headCommit,
-            completedAt: '2026-08-30T00:00:00.000Z',
-            dirty: false,
-            edgeCount: 0,
-            extractorSet: 'fixture-extractor-set',
-            fileCount: 0,
-            graphContentId: `cgc_${'a'.repeat(40)}`,
-            id: `cgsn_${'b'.repeat(40)}`,
-            repositoryId: observed.identity.repositoryId,
-            state: 'ready',
-            symbolCount: 0,
-            worktreeId: observed.identity.worktreeId,
-          },
-          stale: false,
-        };
-        const exactQuery = CodeGraphQueryService.of({
-          ...originalQuery,
-          status: () => Effect.succeed(exactStatus),
-        });
-        const emptyGraphStore = CodeGraphStore.of({
-          acquireSnapshotLease: () => Effect.succeed('fixture-lease'),
-          effectiveSnapshotCitationEvidence: (
-            _databasePath: string,
-            _snapshotId: string,
-            request: {readonly paths?: readonly string[]},
-          ) =>
-            Effect.succeed({
-              fileInventoryCoverage: 'complete',
-              filesByContentHashes: [],
-              filesByPaths: (request.paths ?? []).map(path => ({path})),
-              symbolsByIds: [],
-              symbolsBySemanticLocators: [],
-            }),
-          releaseSnapshotLease: () => Effect.void,
-        } as unknown as CodeGraphStoreShape);
+        const graph = yield* exactCurrentCitationGraph(fixture, []);
 
         const receipt = yield* finalizeDeferredCodeAnchors(fixture.config).pipe(
-          Effect.provideService(CodeGraphQueryService, exactQuery),
-          Effect.provideService(CodeGraphStore, emptyGraphStore),
+          Effect.provideService(CodeGraphQueryService, graph.query),
+          Effect.provideService(CodeGraphStore, graph.store),
         );
 
         expect(receipt).toMatchObject({
-          failedCount: 1,
+          conflictCount: 1,
+          failedCount: 0,
+          pendingCount: 0,
           items: [
             {
-              code: 'code-reference-unresolved',
               memoryUri: MEMORY_URI,
-              recoveryAction: 'replace-memory-code-refs',
-              retryable: false,
-              state: 'failed',
+              reason: 'code-references-absent',
+              state: 'conflict',
             },
           ],
         });
-        expect(receipt.items[0]?.reason).toContain('corrected graph-indexed codeRefs');
+        expect(receipt.items[0]).not.toHaveProperty('recoveryAction');
         expect(JSON.stringify(receipt)).not.toContain(privateLocator);
         expect(JSON.stringify(receipt)).not.toContain(fixture.repository);
-        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(true);
+        expect(yield* hasDeferredCodeAnchorIntent(fixture.config, MEMORY_URI)).toBe(false);
+        expect(
+          parseMemoryDocument(MEMORY_URI, yield* store.read(resourceStoreLocation(fixture.config), MEMORY_URI))
+            ?.metadata.codeCitations?.length ?? 0,
+        ).toBe(0);
+        expect(yield* deferredCodeAnchorDoctorCheck(fixture.config)).toMatchObject({status: 'ok'});
       }),
     ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
@@ -1681,3 +1861,72 @@ function resourceStoreLocation(config: Pick<RuntimeConfig, 'account' | 'agentCon
 function memoryContent(metadata: MemoryMetadata, body: string): string {
   return formatMemoryDocument('MEMORY', metadata, body);
 }
+
+function inventoryFile(repositoryPath: string, source: string, absolutePath: string): CodeGraphInventoryFile {
+  const bytes = new TextEncoder().encode(source);
+  return {
+    blobId: absolutePath,
+    contentHash: codeGraphCommittedFileContentHash('sha1', bytes),
+    language: 'typescript',
+    mode: '100644',
+    path: repositoryPath,
+    size: bytes.byteLength,
+    source: 'commit',
+  };
+}
+
+const exactCurrentCitationGraph = Effect.fn('deferredCodeAnchorTest.exactCurrentGraph')(function* (
+  fixture: {
+    readonly config: RuntimeConfig;
+    readonly repository: string;
+  },
+  files: readonly CodeGraphInventoryFile[],
+) {
+  const originalQuery = yield* CodeGraphQueryService;
+  const observed = yield* originalQuery.status(fixture.config.agentContextHome, fixture.repository, {
+    observeWorktree: true,
+    requestMaintenance: false,
+  });
+  const filesByPath = new Map(files.map(file => [file.path, file]));
+  const exactStatus: CodeGraphStatus = {
+    ...observed,
+    freshness: 'current',
+    readySnapshot: {
+      commit: observed.identity.headCommit,
+      completedAt: '2026-08-30T00:00:00.000Z',
+      dirty: false,
+      edgeCount: 0,
+      extractorSet: 'fixture-extractor-set',
+      fileCount: files.length,
+      graphContentId: `cgc_${'a'.repeat(40)}`,
+      id: `cgsn_${'b'.repeat(40)}`,
+      repositoryId: observed.identity.repositoryId,
+      state: 'ready',
+      symbolCount: 0,
+      worktreeId: observed.identity.worktreeId,
+    },
+    stale: false,
+  };
+  return {
+    query: CodeGraphQueryService.of({
+      ...originalQuery,
+      status: () => Effect.succeed(exactStatus),
+    }),
+    store: CodeGraphStore.of({
+      acquireSnapshotLease: () => Effect.succeed('fixture-lease'),
+      effectiveSnapshotCitationEvidence: (
+        _databasePath: string,
+        _snapshotId: string,
+        request: {readonly paths?: readonly string[]},
+      ) =>
+        Effect.succeed({
+          fileInventoryCoverage: 'complete',
+          filesByContentHashes: [],
+          filesByPaths: (request.paths ?? []).map(path => ({file: filesByPath.get(path), path})),
+          symbolsByIds: [],
+          symbolsBySemanticLocators: [],
+        }),
+      releaseSnapshotLease: () => Effect.void,
+    } as unknown as CodeGraphStoreShape),
+  };
+});

--- a/test/unit/deferred-code-anchor.test.ts
+++ b/test/unit/deferred-code-anchor.test.ts
@@ -780,6 +780,11 @@ describe('deferred code-anchor outbox', () => {
           {cwd: fixture.repository},
         ).pipe(TestClock.withLive);
         const store = yield* ResourceStore;
+        const indexer = yield* CodeGraphIndexer;
+        // Publish first so wrap-heal cannot consume the later-staged intent.
+        yield* indexer
+          .index({cwd: fixture.repository, ensureVectors: false, threadnoteHome: fixture.config.agentContextHome})
+          .pipe(TestClock.withLive);
         const content = memoryContent(fixture.metadata, 'Committed before the foreground deadline.');
         yield* stageDeferredCodeAnchorIntent(fixture.config, {
           memoryContent: content,
@@ -788,10 +793,6 @@ describe('deferred code-anchor outbox', () => {
           request: deferredRequest(fixture.repository, ['src/deadline.ts']),
         });
         yield* store.write(resourceStoreLocation(fixture.config), MEMORY_URI, content, {mode: 'create'});
-        const indexer = yield* CodeGraphIndexer;
-        yield* indexer
-          .index({cwd: fixture.repository, ensureVectors: false, threadnoteHome: fixture.config.agentContextHome})
-          .pipe(TestClock.withLive);
         const [intentPath] = yield* fixtureIntentPaths(fixture);
         const intent = JSON.parse(yield* fixture.fs.readFileString(intentPath)) as {
           repositoryId: string;

--- a/test/unit/effect-architecture.test.ts
+++ b/test/unit/effect-architecture.test.ts
@@ -245,6 +245,25 @@ describe('Effect architecture boundaries', () => {
     expect(importedModuleSpecifiers('context_paging.ts', paging)).toEqual([]);
   });
 
+  it('heals deferred code anchors after in-process graph publication', async () => {
+    const [runtime, commands] = await Promise.all([
+      readFile(join(sourceRoot, 'effect', 'runtime.ts'), 'utf8'),
+      readFile(join(sourceRoot, 'code_graph', 'commands.ts'), 'utf8'),
+    ]);
+    expect(runtime).toContain('withDeferredCodeAnchorIndexHeal');
+    expect(runtime).toContain(
+      'healAfterPublishedGraphIndex(options.threadnoteHome, options.cwd, summary.identity)',
+    );
+    expect(commands).not.toContain('healAnchorsAfterGraphIndex');
+    expect(commands).toContain('healAnchorsAfterWorksetPrepare');
+  });
+
+  it('wakes pending deferred-anchor worktrees only when MCP can read memory and index locally', async () => {
+    const mcp = await readFile(join(sourceRoot, 'mcp', 'server', 'index.ts'), 'utf8');
+    expect(mcp).toContain('refreshPendingDeferredCodeAnchorWorkspaces');
+    expect(mcp).toContain('memoryRead && mcpToolCapabilities(toolset).graphLocal');
+  });
+
   it('keeps standalone worker dispatch independent from application entry modules', async () => {
     const standalone = await readFile(join(sourceRoot, 'standalone.ts'), 'utf8');
     const workerProtocol = await readFile(join(sourceRoot, 'worker_protocol.ts'), 'utf8');

--- a/test/unit/effect-architecture.test.ts
+++ b/test/unit/effect-architecture.test.ts
@@ -251,9 +251,7 @@ describe('Effect architecture boundaries', () => {
       readFile(join(sourceRoot, 'code_graph', 'commands.ts'), 'utf8'),
     ]);
     expect(runtime).toContain('withDeferredCodeAnchorIndexHeal');
-    expect(runtime).toContain(
-      'healAfterPublishedGraphIndex(options.threadnoteHome, options.cwd, summary.identity)',
-    );
+    expect(runtime).toContain('healAfterPublishedGraphIndex(options.threadnoteHome, options.cwd, summary.identity)');
     expect(commands).not.toContain('healAnchorsAfterGraphIndex');
     expect(commands).toContain('healAnchorsAfterWorksetPrepare');
   });

--- a/test/unit/installations.test.ts
+++ b/test/unit/installations.test.ts
@@ -567,6 +567,53 @@ describe('standalone release lifecycle', () => {
     }),
   );
 
+  effectIt.effect(
+    'upgrades a pre-canonical Darwin lease identity so strict terminate can signal the same process',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const baseSystem = yield* SystemInfo;
+            const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-process-lease-upgrade-'});
+            const installRoot = path.join(temporaryRoot, 'install');
+            const processId = 43_001;
+            const stored = 'darwin:Thu Sep 10 16:44:09 2026';
+            const observed = 'darwin-v2:Thu Sep 10 14:44:09 2026';
+            yield* writeProcessLease(fs, path, installRoot, '4.0.0', processId, stored);
+            const leasePath = path.join(installRoot, 'leases', '4.0.0', `${processId}.json`);
+            const running = new Set([processId]);
+            const signals: Array<readonly [number, NodeJS.Signals]> = [];
+            const testSystem = SystemInfo.of({
+              ...baseSystem,
+              canonicalProcessStartIdentity: () => Effect.succeed(observed),
+              environment: () => ({...baseSystem.environment(), THREADNOTE_INSTALL_ROOT: installRoot}),
+              isProcessRunning: candidate => running.has(candidate),
+              processId: 99_999,
+              processStartIdentity: () => Effect.succeed('darwin:Thu 10 Sep 16:44:09 2026'),
+              signalProcess: (candidate, signal) => {
+                signals.push([candidate, signal]);
+                running.delete(candidate);
+              },
+            });
+
+            const termination = yield* terminateSupersededStandaloneProcesses('4.0.1', {
+              gracefulWaitMilliseconds: 0,
+            }).pipe(Effect.provideService(SystemInfo, testSystem));
+            const rewritten = JSON.parse(yield* fs.readFileString(leasePath)) as {processStartIdentity?: string};
+            return {rewrittenIdentity: rewritten.processStartIdentity, signals, termination};
+          }),
+        ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive);
+
+        expect(result.signals).toEqual([[43_001, 'SIGTERM']]);
+        expect(result.termination.signaled.map(lease => lease.processId)).toEqual([43_001]);
+        expect(result.termination.remaining).toEqual([]);
+        expect(result.termination.skippedUnverified).toEqual([]);
+        expect(result.rewrittenIdentity).toBe('darwin-v2:Thu Sep 10 14:44:09 2026');
+      }),
+  );
+
   effectIt.effect('reports but never signals superseded leases without verifiable process identity', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(

--- a/test/unit/mcp-native-read-batch.test.ts
+++ b/test/unit/mcp-native-read-batch.test.ts
@@ -1,0 +1,136 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {describe, expect} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {ResourceStore} from '../../src/effect/resource-store.js';
+import {runNativeReadTool} from '../../src/mcp/server/memory.js';
+import {memoryReadResourcesFromNativeResult} from '../../src/mcp/server/recall.js';
+import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import {formatMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const PRESENT_BODY = 'Present memory body for mixed batch read.';
+
+function memoryMetadata(topic: string): MemoryMetadata {
+  return {
+    kind: 'durable',
+    project: 'threadnote',
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    sourceAgentClient: 'codex',
+    status: 'active',
+    timestamp: '2026-09-10T00:00:00.000Z',
+    topic,
+  };
+}
+
+function memoryUri(topic: string): string {
+  return `threadnote://user/tester/memories/durable/projects/threadnote/${topic}.md`;
+}
+
+describe('MCP native batch read_context', () => {
+  effectIt.effect('returns mixed success when some requested memories are missing', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-read-batch-'});
+        const config: RuntimeConfig = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'threadnote',
+          manifestPath: path.join(home, 'seed-manifest.yaml'),
+          user: 'tester',
+        };
+        const presentUri = memoryUri('present-read');
+        const missingUri = memoryUri('missing-read');
+        const store = yield* ResourceStore;
+        yield* store.write(
+          {account: config.account, home: config.agentContextHome, user: config.user},
+          presentUri,
+          formatMemoryDocument('MEMORY', memoryMetadata('present-read'), PRESENT_BODY),
+          {mode: 'create'},
+        );
+
+        const result = yield* runNativeReadTool(config, [missingUri, presentUri]);
+        const texts = result.content.filter(item => item.type === 'text').map(item => item.text);
+        const canonicalRead = result._meta?.['threadnote.io/canonical-read'] as
+          | {readonly missing?: readonly string[]; readonly resources?: readonly {readonly requestedUri: string}[]}
+          | undefined;
+
+        expect(result.isError).not.toBe(true);
+        expect(texts.some(text => text.includes(PRESENT_BODY))).toBe(true);
+        expect(canonicalRead?.missing).toEqual([missingUri]);
+        expect(canonicalRead?.resources?.map(resource => resource.requestedUri)).toEqual([presentUri]);
+        expect(
+          memoryReadResourcesFromNativeResult(result, [missingUri, presentUri])?.map(resource => resource.uri),
+        ).toEqual([presentUri]);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('keeps the batch as an error when every requested memory is missing', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-read-batch-missing-'});
+        const config: RuntimeConfig = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'threadnote',
+          manifestPath: path.join(home, 'seed-manifest.yaml'),
+          user: 'tester',
+        };
+
+        const result = yield* runNativeReadTool(config, [memoryUri('missing-a'), memoryUri('missing-b')]);
+        expect(result.isError).toBe(true);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect.prop(
+    'succeeds for each present URI and errors only when none are present',
+    {
+      flags: FC.array(FC.boolean(), {maxLength: 4, minLength: 1}),
+    },
+    ({flags}) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-read-batch-prop-'});
+          const config: RuntimeConfig = {
+            account: 'local',
+            agentContextHome: home,
+            agentId: 'threadnote',
+            manifestPath: path.join(home, 'seed-manifest.yaml'),
+            user: 'tester',
+          };
+          const store = yield* ResourceStore;
+          const location = {account: config.account, home: config.agentContextHome, user: config.user};
+          const uris = flags.map((_, index) => memoryUri(`batch-${index}`));
+          yield* Effect.forEach(
+            flags.flatMap((present, index) => (present ? [index] : [])),
+            index =>
+              store.write(
+                location,
+                uris[index],
+                formatMemoryDocument('MEMORY', memoryMetadata(`batch-${index}`), `Present body ${index}`),
+                {mode: 'create'},
+              ),
+            {concurrency: 1},
+          );
+
+          const result = yield* runNativeReadTool(config, uris);
+          const presentCount = flags.filter(Boolean).length;
+          const canonicalRead = result._meta?.['threadnote.io/canonical-read'] as
+            {readonly resources?: readonly unknown[]} | undefined;
+          expect(canonicalRead?.resources?.length ?? 0).toBe(presentCount);
+          expect(result.isError === true).toBe(presentCount === 0);
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    {fastCheck: {numRuns: 16}},
+  );
+});

--- a/test/unit/memory-native.test.ts
+++ b/test/unit/memory-native.test.ts
@@ -909,6 +909,71 @@ describe('native memory workflow', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  it.effect('does not advertise a deleted memory that still has a stale lexical row', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-native-stale-lexical-'});
+        const manifestPath = path.join(home, 'seed-manifest.yaml');
+        yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
+        const config: RuntimeConfig = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'threadnote',
+          manifestPath,
+          user: 'tester',
+        };
+        const memoryRoot = path.join(
+          home,
+          'data',
+          'local',
+          'user',
+          'tester',
+          'memories',
+          'durable',
+          'projects',
+          'threadnote',
+        );
+        const ghostUri = 'threadnote://user/tester/memories/durable/projects/threadnote/stale-lexical-ghost.md';
+        const sentinel = 'STALE-LEXICAL-GHOST-847291056';
+        yield* fs.makeDirectory(memoryRoot, {recursive: true});
+        yield* fs.writeFileString(
+          path.join(memoryRoot, 'stale-lexical-ghost.md'),
+          [
+            'MEMORY',
+            'kind: durable',
+            'status: active',
+            'project: threadnote',
+            'topic: stale-lexical-ghost',
+            'source_agent_client: test',
+            'timestamp: 2026-07-30T00:00:00.000Z',
+            '',
+            '# Stale lexical ghost',
+            '',
+            sentinel,
+          ].join('\n'),
+        );
+        yield* loadRecallIndex(config, {
+          forceRefresh: true,
+          includeInactive: false,
+          query: sentinel,
+        });
+        yield* fs.remove(path.join(memoryRoot, 'stale-lexical-ghost.md'));
+
+        const recalled = yield* captureConsole(
+          runRecall(config, {
+            inferScope: false,
+            query: sentinel,
+            threshold: '0.1',
+          }),
+        );
+
+        expect(recalled.output).not.toContain(ghostUri);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   it.effect('round-trips the default pack root into the current user memories namespace', () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/test/unit/process-diagnostics.test.ts
+++ b/test/unit/process-diagnostics.test.ts
@@ -259,6 +259,64 @@ describe('process diagnostics', () => {
       }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
   );
 
+  it.effect('keeps a live MCP registration when canonical observation is unread and locale observation disagrees', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-canonical-unread-keep-'});
+      const processId = 1_234_512;
+      const registrationPath = join(home, 'runtime', 'processes', `${processId}.json`);
+      const stored = testRegistration(
+        processId,
+        'mcp',
+        'darwin-v2:Thu Sep 10 16:19:47 2026',
+        'canonical-unread-keep-token',
+      );
+      yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+      yield* fileSystem.writeFileString(registrationPath, `${JSON.stringify(stored)}\n`);
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId,
+        canonicalProcessStartIdentity: () => succeedUndefined,
+        processStartIdentity: () => Effect.succeed('darwin:Thu 10 Sep 18:19:47 2026'),
+      });
+      const listed = yield* readThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      expect(listed.processes).toEqual([expect.objectContaining({processId, role: 'mcp'})]);
+      expect(yield* fileSystem.exists(registrationPath)).toBe(true);
+      expect(JSON.parse(yield* fileSystem.readFileString(registrationPath))).toMatchObject({
+        processId,
+        processStartIdentity: 'darwin:Thu 10 Sep 18:19:47 2026',
+      });
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.effect('restores a live registration file after inventory garbage-collected it', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-restore-registration-'});
+      const config = {agentContextHome: home};
+      yield* withThreadnoteProcessRegistration(
+        home,
+        'mcp',
+        Effect.gen(function* () {
+          const registrationPath = join(home, 'runtime', 'processes', `${process.pid}.json`);
+          expect(yield* fileSystem.exists(registrationPath)).toBe(true);
+          yield* fileSystem.remove(registrationPath);
+          expect(yield* fileSystem.exists(registrationPath)).toBe(false);
+          yield* withThreadnoteProcessActivity('mcp', 'mcp-server', Effect.void, {
+            idleTransitionDelayMilliseconds: 60_000,
+          });
+          expect(yield* fileSystem.exists(registrationPath)).toBe(true);
+          const listed = yield* readThreadnoteProcessDiagnostics(config);
+          expect(listed.processes).toEqual([expect.objectContaining({processId: process.pid, role: 'mcp'})]);
+        }),
+        'mcp-server',
+      );
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
   it.effect('removes a registration when the canonical process instance has been replaced', () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/test/unit/process-diagnostics.test.ts
+++ b/test/unit/process-diagnostics.test.ts
@@ -229,6 +229,65 @@ describe('process diagnostics', () => {
     }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer)),
   );
 
+  it.effect(
+    'keeps a live MCP registration when the observer locale no longer matches the stored Darwin start string',
+    () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const nativeSystem = yield* SystemInfo;
+        const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-locale-keep-'});
+        const processId = 1_234_510;
+        const registrationPath = join(home, 'runtime', 'processes', `${processId}.json`);
+        const stored = testRegistration(processId, 'mcp', 'darwin:Thu Sep 10 16:44:09 2026', 'locale-keep-token-value');
+        yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+        yield* fileSystem.writeFileString(registrationPath, `${JSON.stringify(stored)}\n`);
+        const testSystem = SystemInfo.of({
+          ...nativeSystem,
+          isProcessRunning: id => id === processId,
+          canonicalProcessStartIdentity: () => Effect.succeed('darwin-v2:Thu Sep 10 14:44:09 2026'),
+          processStartIdentity: () => Effect.succeed('darwin:Thu 10 Sep 16:44:09 2026'),
+        });
+        const listed = yield* readThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(listed.processes).toEqual([expect.objectContaining({processId, role: 'mcp'})]);
+        expect(yield* fileSystem.exists(registrationPath)).toBe(true);
+        expect(JSON.parse(yield* fileSystem.readFileString(registrationPath))).toMatchObject({
+          processId,
+          processStartIdentity: 'darwin-v2:Thu Sep 10 14:44:09 2026',
+        });
+      }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.effect('removes a registration when the canonical process instance has been replaced', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-canonical-stale-'});
+      const processId = 1_234_511;
+      const registrationPath = join(home, 'runtime', 'processes', `${processId}.json`);
+      const stored = testRegistration(
+        processId,
+        'mcp',
+        'darwin-v2:Thu Sep 10 14:44:09 2026',
+        'canonical-stale-token-value',
+      );
+      yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+      yield* fileSystem.writeFileString(registrationPath, `${JSON.stringify(stored)}\n`);
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId,
+        canonicalProcessStartIdentity: () => Effect.succeed('darwin-v2:Thu Sep 10 15:00:00 2026'),
+        processStartIdentity: () => Effect.succeed('darwin:Thu Sep 10 16:44:09 2026'),
+      });
+      const listed = yield* readThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      expect(listed.processes).toEqual([]);
+      expect(yield* fileSystem.exists(registrationPath)).toBe(false);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
   it.effect('reports termination after the exact registered process exits on SIGTERM', () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/test/unit/process-identity.test.ts
+++ b/test/unit/process-identity.test.ts
@@ -3,7 +3,11 @@ import {Effect} from 'effect';
 import {it as effectIt} from '@effect/vitest';
 import {describe, expect, it} from 'vitest';
 import {succeedUndefined} from '../../src/effect/optional.js';
-import {observeProcessInstanceIdentity, processInstanceIdentityMatches} from '../../src/process/process_identity.js';
+import {
+  observeCanonicalProcessInstanceIdentity,
+  observeProcessInstanceIdentity,
+  processInstanceIdentityMatches,
+} from '../../src/process/process_identity.js';
 
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const;
@@ -46,10 +50,17 @@ describe('process instance identity', () => {
     fc.assert(
       fc.property(darwinCLocaleStart, start => {
         expect(processInstanceIdentityMatches(`darwin:${start}`, `darwin-v2:${start}`)).toBe(true);
+        expect(processInstanceIdentityMatches(`darwin-v2:${start}`, `darwin:${start}`)).toBe(true);
         expect(processInstanceIdentityMatches(`darwin-v2:${start}`, `darwin-v2:${start}`)).toBe(true);
       }),
       {numRuns: 200},
     );
+  });
+
+  it('keeps a canonical Darwin row when observation falls back to a locale-sensitive string', () => {
+    expect(
+      processInstanceIdentityMatches('darwin-v2:Thu Sep 10 16:19:47 2026', 'darwin:Thu 10 Sep 18:19:47 2026'),
+    ).toBe(true);
   });
 });
 
@@ -89,6 +100,20 @@ describe('observeProcessInstanceIdentity', () => {
         1,
       );
       expect(observed).toBe('darwin:fallback');
+    }),
+  );
+});
+
+describe('observeCanonicalProcessInstanceIdentity', () => {
+  effectIt.effect('does not fall back to a locale-sensitive identity for keep decisions', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeCanonicalProcessInstanceIdentity(
+        {
+          canonicalProcessStartIdentity: () => succeedUndefined,
+        },
+        1,
+      );
+      expect(observed).toBeUndefined();
     }),
   );
 });

--- a/test/unit/process-identity.test.ts
+++ b/test/unit/process-identity.test.ts
@@ -1,0 +1,94 @@
+import fc from 'fast-check';
+import {Effect} from 'effect';
+import {it as effectIt} from '@effect/vitest';
+import {describe, expect, it} from 'vitest';
+import {succeedUndefined} from '../../src/effect/optional.js';
+import {observeProcessInstanceIdentity, processInstanceIdentityMatches} from '../../src/process/process_identity.js';
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const;
+
+const darwinCLocaleStart = fc
+  .tuple(
+    fc.constantFrom(...WEEKDAYS),
+    fc.constantFrom(...MONTHS),
+    fc.integer({min: 1, max: 31}),
+    fc.integer({min: 0, max: 23}),
+    fc.integer({min: 0, max: 59}),
+    fc.integer({min: 0, max: 59}),
+    fc.integer({min: 2020, max: 2035}),
+  )
+  .map(([weekday, month, day, hour, minute, second, year]) => {
+    const dayField = day < 10 ? ` ${day}` : String(day);
+    const time = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`;
+    return `${weekday} ${month} ${dayField} ${time} ${year}`;
+  });
+
+describe('process instance identity', () => {
+  it('keeps a live process when observation cannot be read', () => {
+    expect(processInstanceIdentityMatches('darwin-v2:Sat Aug  8 23:04:27 2026', undefined)).toBe(true);
+    expect(processInstanceIdentityMatches(undefined, 'darwin-v2:Sat Aug  8 23:04:27 2026')).toBe(true);
+  });
+
+  it('rejects a canonical identity that no longer matches the running process', () => {
+    expect(
+      processInstanceIdentityMatches('darwin-v2:Sat Aug  8 23:04:27 2026', 'darwin-v2:Sun Aug  9 00:00:00 2026'),
+    ).toBe(false);
+  });
+
+  it('does not treat two different locale-sensitive Darwin strings as the same process', () => {
+    expect(processInstanceIdentityMatches('darwin:Thu Sep 10 16:44:09 2026', 'darwin:Thu 10 Sep 16:44:09 2026')).toBe(
+      false,
+    );
+  });
+
+  it('accepts a pre-canonical Darwin row once the observer has a locale-stable identity', () => {
+    fc.assert(
+      fc.property(darwinCLocaleStart, start => {
+        expect(processInstanceIdentityMatches(`darwin:${start}`, `darwin-v2:${start}`)).toBe(true);
+        expect(processInstanceIdentityMatches(`darwin-v2:${start}`, `darwin-v2:${start}`)).toBe(true);
+      }),
+      {numRuns: 200},
+    );
+  });
+});
+
+describe('observeProcessInstanceIdentity', () => {
+  effectIt.effect('prefers canonical process start identity when it is defined', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeProcessInstanceIdentity(
+        {
+          canonicalProcessStartIdentity: () => Effect.succeed('darwin-v2:canonical'),
+          processStartIdentity: () => Effect.succeed('darwin:fallback'),
+        },
+        1,
+      );
+      expect(observed).toBe('darwin-v2:canonical');
+    }),
+  );
+
+  effectIt.effect('falls back to locale-sensitive identity when canonical observation is missing', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeProcessInstanceIdentity(
+        {
+          processStartIdentity: () => Effect.succeed('darwin:fallback'),
+        },
+        1,
+      );
+      expect(observed).toBe('darwin:fallback');
+    }),
+  );
+
+  effectIt.effect('falls back when canonical observation returns undefined', () =>
+    Effect.gen(function* () {
+      const observed = yield* observeProcessInstanceIdentity(
+        {
+          canonicalProcessStartIdentity: () => succeedUndefined,
+          processStartIdentity: () => Effect.succeed('darwin:fallback'),
+        },
+        1,
+      );
+      expect(observed).toBe('darwin:fallback');
+    }),
+  );
+});

--- a/test/unit/recall.runtime.test.ts
+++ b/test/unit/recall.runtime.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../src/models/inference.js', () => ({
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {captureConsole} from '../../src/effect/console.js';
 import {LocalModelRuntime} from '../../src/effect/ai/local-model-runtime.js';
-import {runRecall} from '../../src/memory/index.js';
+import {readMemoryRecordsByUri, runRecall} from '../../src/memory/index.js';
 import {BUILTIN_MODEL_MANIFESTS} from '../../src/models/builtin.js';
 import {LocalModelCatalog} from '../../src/models/catalog.js';
 import {selectLocalModel} from '../../src/models/selection.js';
@@ -692,6 +692,71 @@ describe('recall runtime orchestration', () => {
 
       expect(emptyHydration.ranked.map(ranked => ranked.uri)).toContain(presentUri);
       expect(loadedMissing.ranked.map(ranked => ranked.uri)).not.toContain(ghostUri);
+    }),
+  );
+  effectIt.effect('drops an indexed memory when extra record hydration misses an empty store', () =>
+    Effect.gen(function* () {
+      const home = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'threadnote-recall-stale-lexical-')));
+      homes.push(home);
+      const ghostUri = 'threadnote://user/tester/memories/durable/projects/threadnote/stale-lexical-ghost.md';
+      const sentinel = 'STALE-LEXICAL-GHOST-847291056';
+      const memoryRoot = join(home, 'data', 'local', 'user', 'tester', 'memories', 'durable', 'projects', 'threadnote');
+      const ghostPath = join(memoryRoot, 'stale-lexical-ghost.md');
+      yield* Effect.promise(() => mkdir(memoryRoot, {recursive: true}));
+      yield* Effect.promise(() =>
+        writeFile(
+          ghostPath,
+          [
+            'MEMORY',
+            'kind: durable',
+            'status: active',
+            'project: threadnote',
+            'topic: stale-lexical-ghost',
+            'source_agent_client: test',
+            'timestamp: 2026-07-30T00:00:00.000Z',
+            '',
+            '# Stale lexical ghost',
+            '',
+            sentinel,
+          ].join('\n'),
+        ),
+      );
+      const config: RuntimeConfig = {
+        account: 'local',
+        agentContextHome: home,
+        agentId: 'threadnote',
+        manifestPath: join(home, 'seed-manifest.yaml'),
+        user: 'tester',
+      };
+      yield* loadRecallIndex(config, {
+        forceRefresh: true,
+        includeInactive: false,
+        query: sentinel,
+      }).pipe(provideTestLayer(ApplicationLayer));
+      yield* Effect.promise(() => rm(ghostPath, {force: true}));
+      const prepared = yield* prepareRecallSections(config, {
+        allowExactRescue: false,
+        exactMatches: [],
+        feedbackQuery: sentinel,
+        includeInactive: false,
+        limit: 5,
+        passes: [
+          [
+            {
+              category: 'memories',
+              contextType: 'memory',
+              score: 1,
+              snippet: sentinel,
+              uri: ghostUri,
+            },
+          ],
+        ],
+        query: sentinel,
+        readRecords: uris => readMemoryRecordsByUri(config, uris),
+        semanticResult: Option.none(),
+      }).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(prepared.ranked.map(ranked => ranked.uri)).not.toContain(ghostUri);
     }),
   );
   effectIt.effect('surfaces one CLI warning when exact and ranked lexical recovery both fail', () =>

--- a/test/unit/recall.runtime.test.ts
+++ b/test/unit/recall.runtime.test.ts
@@ -608,7 +608,24 @@ describe('recall runtime orchestration', () => {
             ],
           ],
           query: 'file fallback anchor',
-          readRecords: () => Effect.succeed([]),
+          readRecords: () =>
+            Effect.succeed([
+              {
+                body: 'File fallback anchor remains available.',
+                content:
+                  'MEMORY\nkind: durable\nstatus: active\nproject: threadnote\ntopic: file-fallback\n\nFile fallback anchor remains available.',
+                headerTitle: 'MEMORY',
+                metadata: {
+                  kind: 'durable',
+                  project: 'threadnote',
+                  sourceAgentClient: 'test',
+                  status: 'active',
+                  timestamp: '2026-07-23T00:00:00.000Z',
+                  topic: 'file-fallback',
+                },
+                uri: fallbackUri,
+              },
+            ]),
           semanticResult: Option.none(),
         },
       ).pipe(provideTestLayer(ApplicationLayer));

--- a/test/unit/recall.runtime.test.ts
+++ b/test/unit/recall.runtime.test.ts
@@ -634,6 +634,66 @@ describe('recall runtime orchestration', () => {
       expect(prepared.operationalWarnings).toEqual([expect.objectContaining({code: 'lexical_index_unavailable'})]);
     }),
   );
+  effectIt.effect('distinguishes empty record hydration from a loaded set that omits a memory URI', () =>
+    Effect.gen(function* () {
+      const home = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'threadnote-recall-empty-records-')));
+      homes.push(home);
+      const presentUri = 'threadnote://user/tester/memories/durable/projects/threadnote/present-ranked.md';
+      const ghostUri = 'threadnote://user/tester/memories/durable/projects/threadnote/ghost-ranked.md';
+      const presentRecord = {
+        body: 'Present ranked memory body remains available.',
+        content:
+          'MEMORY\nkind: durable\nstatus: active\nproject: threadnote\ntopic: present-ranked\n\nPresent ranked memory body remains available.',
+        headerTitle: 'MEMORY' as const,
+        metadata: {
+          kind: 'durable' as const,
+          project: 'threadnote',
+          sourceAgentClient: 'test',
+          status: 'active' as const,
+          timestamp: '2026-07-23T00:00:00.000Z',
+          topic: 'present-ranked',
+        },
+        uri: presentUri,
+      };
+      const memoryHit = (uri: string) => ({
+        category: 'memories' as const,
+        contextType: 'memory' as const,
+        score: 1,
+        snippet: 'Present ranked memory body remains available.',
+        uri,
+      });
+      const config = {
+        account: 'local',
+        agentContextHome: home,
+        user: 'tester',
+      };
+      const emptyHydration = yield* prepareRecallSections(config, {
+        allowExactRescue: false,
+        exactMatches: [],
+        feedbackQuery: 'Present ranked memory body',
+        includeInactive: false,
+        limit: 5,
+        passes: [[memoryHit(presentUri)]],
+        query: 'Present ranked memory body',
+        readRecords: () => Effect.succeed([]),
+        semanticResult: Option.none(),
+      }).pipe(provideTestLayer(ApplicationLayer));
+      const loadedMissing = yield* prepareRecallSections(config, {
+        allowExactRescue: false,
+        exactMatches: [],
+        feedbackQuery: 'Present ranked memory body',
+        includeInactive: false,
+        limit: 5,
+        passes: [[memoryHit(ghostUri)]],
+        query: 'Present ranked memory body',
+        readRecords: () => Effect.succeed([presentRecord]),
+        semanticResult: Option.none(),
+      }).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(emptyHydration.ranked.map(ranked => ranked.uri)).toContain(presentUri);
+      expect(loadedMissing.ranked.map(ranked => ranked.uri)).not.toContain(ghostUri);
+    }),
+  );
   effectIt.effect('surfaces one CLI warning when exact and ranked lexical recovery both fail', () =>
     Effect.gen(function* () {
       const home = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'threadnote-recall-cli-index-warning-')));

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1120,6 +1120,58 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     expect(loadedMissing.ranked.map(hit => hit.uri)).not.toContain(ghostUri);
   });
 
+  it('drops extra-hydration misses even when records is an empty array', () => {
+    const liveUri = 'threadnote://user/me/memories/durable/projects/threadnote/live-ranked-gate.md';
+    const ghostUri = 'threadnote://user/me/memories/durable/projects/threadnote/ghost-ranked-gate.md';
+    const indexedCandidates = [
+      {
+        fields: {identifiers: ['ranked-live-gate'], project: 'threadnote', title: 'Live', topic: 'live-ranked-gate'},
+        text: 'ranked-live-gate live memory body',
+        uri: liveUri,
+      },
+      {
+        fields: {identifiers: ['ranked-live-gate'], project: 'threadnote', title: 'Ghost', topic: 'ghost-ranked-gate'},
+        text: 'ranked-live-gate ghost memory body',
+        uri: ghostUri,
+      },
+    ];
+    const sections = buildRecallSections([], [], 12, {
+      absentMemoryUris: [ghostUri],
+      indexedCandidates,
+      query: 'ranked-live-gate',
+      records: [],
+    });
+
+    expect(sections.ranked.map(hit => hit.uri)).toContain(liveUri);
+    expect(sections.ranked.map(hit => hit.uri)).not.toContain(ghostUri);
+  });
+
+  it('never ranks extra-hydration misses even when records is empty', () => {
+    fc.assert(
+      fc.property(fc.array(fc.boolean(), {minLength: 1, maxLength: 5}), flags => {
+        const candidates = flags.map((_live, index) => ({
+          fields: {
+            identifiers: [`ranked-live-gate-${index}`],
+            project: 'threadnote',
+            title: `Candidate ${index}`,
+            topic: `candidate-${index}`,
+          },
+          text: `ranked-live-gate candidate ${index}`,
+          uri: `threadnote://user/me/memories/durable/projects/threadnote/ranked-gate-${index}.md`,
+        }));
+        const absentMemoryUris = flags.flatMap((live, index) => (live ? [] : [candidates[index].uri]));
+        const sections = buildRecallSections([], [], 12, {
+          absentMemoryUris,
+          indexedCandidates: candidates,
+          query: 'ranked-live-gate',
+          records: [],
+        });
+        const rankedMemories = sections.ranked.map(hit => hit.uri).filter(uri => uri.includes('/memories/'));
+        expect(rankedMemories.every(uri => !absentMemoryUris.includes(uri))).toBe(true);
+      }),
+    );
+  });
+
   it('ranks only live memory URIs when a non-empty record set is provided', () => {
     fc.assert(
       fc.property(fc.array(fc.boolean(), {minLength: 1, maxLength: 5}), flags => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -2,7 +2,9 @@ import {chmod, mkdtemp, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import {Effect} from 'effect';
+import fc from 'fast-check';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+import type {MemoryRecord} from '../../src/memory/document.js';
 import {
   applyExactMatchBoost,
   buildRecallSections,
@@ -42,6 +44,23 @@ import {
   uniqueUsefulWorkspaceTerms,
 } from '../../src/utils.js';
 import {runEffect} from '../helpers/effect-runtime.js';
+
+function rankingMemoryRecord(uri: string, body: string): MemoryRecord {
+  return {
+    body,
+    content: `MEMORY\nkind: durable\nstatus: active\nproject: threadnote\ntopic: topic\n\n${body}`,
+    headerTitle: 'MEMORY',
+    metadata: {
+      kind: 'durable',
+      project: 'threadnote',
+      sourceAgentClient: 'test',
+      status: 'active',
+      timestamp: '2026-07-23T00:00:00.000Z',
+      topic: 'topic',
+    },
+    uri,
+  };
+}
 
 const collectExactMatches = (
   terms: readonly string[],
@@ -1034,6 +1053,70 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     });
 
     expect(sections.ranked.map(hit => hit.uri)).toEqual([selectedUri]);
+  });
+
+  it('does not rank an indexed memory URI that is absent from provided records', () => {
+    const liveUri = 'threadnote://user/me/memories/durable/projects/threadnote/live-ranked-gate.md';
+    const ghostUri = 'threadnote://user/me/memories/durable/projects/threadnote/ghost-ranked-gate.md';
+    const resourceUri = 'threadnote://resources/repos/threadnote/ranked-live-gate.md';
+    const sections = buildRecallSections([], [], 12, {
+      indexedCandidates: [
+        {
+          fields: {identifiers: ['ranked-live-gate'], project: 'threadnote', title: 'Live', topic: 'live-ranked-gate'},
+          text: 'ranked-live-gate live memory body',
+          uri: liveUri,
+        },
+        {
+          fields: {
+            identifiers: ['ranked-live-gate'],
+            project: 'threadnote',
+            title: 'Ghost',
+            topic: 'ghost-ranked-gate',
+          },
+          text: 'ranked-live-gate ghost memory body',
+          uri: ghostUri,
+        },
+        {
+          fields: {identifiers: ['ranked-live-gate'], project: 'threadnote', title: 'Resource', topic: 'resource-gate'},
+          text: 'ranked-live-gate resource body',
+          uri: resourceUri,
+        },
+      ],
+      query: 'ranked-live-gate',
+      records: [rankingMemoryRecord(liveUri, 'ranked-live-gate live memory body')],
+    });
+
+    expect(sections.ranked.map(hit => hit.uri)).toContain(liveUri);
+    expect(sections.ranked.map(hit => hit.uri)).not.toContain(ghostUri);
+    expect(sections.ranked.map(hit => hit.uri)).toContain(resourceUri);
+  });
+
+  it('ranks only live memory URIs when records are provided', () => {
+    fc.assert(
+      fc.property(fc.array(fc.boolean(), {minLength: 1, maxLength: 5}), flags => {
+        const candidates = flags.map((_live, index) => ({
+          fields: {
+            identifiers: [`ranked-live-gate-${index}`],
+            project: 'threadnote',
+            title: `Candidate ${index}`,
+            topic: `candidate-${index}`,
+          },
+          text: `ranked-live-gate candidate ${index}`,
+          uri: `threadnote://user/me/memories/durable/projects/threadnote/ranked-gate-${index}.md`,
+        }));
+        const records = flags.flatMap((live, index) =>
+          live ? [rankingMemoryRecord(candidates[index].uri, candidates[index].text)] : [],
+        );
+        const sections = buildRecallSections([], [], 12, {
+          indexedCandidates: candidates,
+          query: 'ranked-live-gate',
+          records,
+        });
+        const liveUris = new Set(records.map(record => record.uri));
+        const rankedMemories = sections.ranked.map(hit => hit.uri).filter(uri => uri.includes('/memories/'));
+        expect(rankedMemories.every(uri => liveUris.has(uri))).toBe(true);
+      }),
+    );
   });
 
   it('bounds full hybrid ranking of lexical index matches before graph and BM25 work', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1091,7 +1091,36 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     expect(sections.ranked.map(hit => hit.uri)).toContain(resourceUri);
   });
 
-  it('ranks only live memory URIs when records are provided', () => {
+  it('keeps indexed memory URIs when records is an empty array rather than a loaded set', () => {
+    const liveUri = 'threadnote://user/me/memories/durable/projects/threadnote/live-ranked-gate.md';
+    const ghostUri = 'threadnote://user/me/memories/durable/projects/threadnote/ghost-ranked-gate.md';
+    const indexedCandidates = [
+      {
+        fields: {identifiers: ['ranked-live-gate'], project: 'threadnote', title: 'Live', topic: 'live-ranked-gate'},
+        text: 'ranked-live-gate live memory body',
+        uri: liveUri,
+      },
+      {
+        fields: {identifiers: ['ranked-live-gate'], project: 'threadnote', title: 'Ghost', topic: 'ghost-ranked-gate'},
+        text: 'ranked-live-gate ghost memory body',
+        uri: ghostUri,
+      },
+    ];
+    const ranking = {indexedCandidates, query: 'ranked-live-gate'};
+    const unchecked = buildRecallSections([], [], 12, ranking);
+    const emptyHydration = buildRecallSections([], [], 12, {...ranking, records: []});
+    const loadedMissing = buildRecallSections([], [], 12, {
+      ...ranking,
+      records: [rankingMemoryRecord(liveUri, 'ranked-live-gate live memory body')],
+    });
+
+    expect(emptyHydration.ranked.map(hit => hit.uri)).toEqual(unchecked.ranked.map(hit => hit.uri));
+    expect(emptyHydration.ranked.map(hit => hit.uri)).toEqual(expect.arrayContaining([liveUri, ghostUri]));
+    expect(loadedMissing.ranked.map(hit => hit.uri)).toContain(liveUri);
+    expect(loadedMissing.ranked.map(hit => hit.uri)).not.toContain(ghostUri);
+  });
+
+  it('ranks only live memory URIs when a non-empty record set is provided', () => {
     fc.assert(
       fc.property(fc.array(fc.boolean(), {minLength: 1, maxLength: 5}), flags => {
         const candidates = flags.map((_live, index) => ({
@@ -1112,8 +1141,18 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
           query: 'ranked-live-gate',
           records,
         });
-        const liveUris = new Set(records.map(record => record.uri));
         const rankedMemories = sections.ranked.map(hit => hit.uri).filter(uri => uri.includes('/memories/'));
+        if (records.length === 0) {
+          const unchecked = buildRecallSections([], [], 12, {
+            indexedCandidates: candidates,
+            query: 'ranked-live-gate',
+          });
+          expect(rankedMemories).toEqual(
+            unchecked.ranked.map(hit => hit.uri).filter(uri => uri.includes('/memories/')),
+          );
+          return;
+        }
+        const liveUris = new Set(records.map(record => record.uri));
         expect(rankedMemories.every(uri => liveUris.has(uri))).toBe(true);
       }),
     );


### PR DESCRIPTION
## Summary
- Heal matching deferred code-anchor intents after any in-process graph publication. Still-present worktrees get background watcher refresh (`admissionClass: background`); deleted worktrees are never rebound onto a sibling or main checkout.
- Leftover outbox: missing or unusable `callerCwd` discards the private intent (`conflict` / `caller-checkout-missing`). Identity mismatch stays `caller-repository-identity-changed`. Still-present `code-reference-unresolved` locators use subset capture (`omitUnresolved`) on that worktree’s exact-current graph: ≥1 hit CAS-cites and finalizes; 0 hits discard with `conflict` / `code-references-absent`. Writes stay all-or-nothing. Retryable graph unreadiness stays pending and schedules refresh.
- Darwin process-start identity: write and observe canonical `darwin-v2` (`LANG=C`, `TZ=UTC`). Inventory and lease **keep** are loose (`darwin:` stored vs live `darwin-v2` counts as the same instance). Terminate and signal stay **strict**. On keep, rewrite stored registry and standalone-lease identity so a later SIGTERM still matches.
- Ranked recall drops `/memories/` URIs with no live record when `records` is provided. Extra `readRecords` covers unread indexed memory URIs. Resource URIs may rank without a MemoryRecord.
- Batch `read_context` is per-URI: mixed success plus `_meta.missing`; `isError` only if all fail. Identity-alias resolution before the loop stays fail-closed. Native resource mapping iterates canonical-read resources only.

## Test plan
- [ ] CI runs the full suite (do not rely on a local full-suite run).
- [ ] Focused Vitest already covered process identity/diagnostics/installations, recall ranking and batch read, and deferred-anchor refresh/heal/property/unit during implementation.
- [ ] After exact-HEAD `dev:install-global`: `threadnote --version` matches HEAD; doctor deferred-anchor WARN; `threadnote processes` still lists Cursor MCP from a non-C locale; mixed `read_context` returns present records plus `_meta.missing`; leftover outbox discard/replace as expected.
- [ ] Restart Manager (or wait for the inventory poll) so registry rows rewrite to `darwin-v2`. Cursor MCP stays pinned until reconnect.