### PR TITLE
Release Threadnote 4.6.11: skip empty post-index deferred-anchor heal

### DIFF
--- a/.github/release-notes/v4.6.11.md
+++ b/.github/release-notes/v4.6.11.md
@@ -1,0 +1,7 @@
+## What's new
+
+Threadnote 4.6.11 no longer runs deferred-anchor heal after a graph index when there is no private memory `data/` tree, so a short index no longer holds the graph session open for extra SQLite work.
+
+### Skip empty post-index heal
+
+After `threadnote graph index` publishes, Threadnote skips deferred-anchor recovery unless the private home already has a `data/` directory. Index-only homes no longer keep the graph session open for extra SQLite work just to discover there is nothing to heal. Homes that already store memories still finalize pending private code links after publication.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.10",
+  "version": "4.6.11",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/memory/deferred_code_anchor_index_heal.ts
+++ b/src/memory/deferred_code_anchor_index_heal.ts
@@ -1,4 +1,4 @@
-import {Context, Effect} from 'effect';
+import {Context, Effect, FileSystem, Option, Path} from 'effect';
 import type {CodeGraphIndexOptions, CodeGraphIndexerShape} from '../code_graph/indexer_types.js';
 import type {CodeGraphIndexSummary, RepositoryIdentity} from '../code_graph/types.js';
 import {getRuntimeConfig} from '../runtime.js';
@@ -20,10 +20,19 @@ const publishedGraphIndexHeal = (
   cwd: string,
   identity: Pick<RepositoryIdentity, 'repositoryId' | 'worktreeId'>,
 ) =>
-  getRuntimeConfig({home: threadnoteHome}).pipe(
-    Effect.flatMap(config => healAnchorsAfterGraphIndex(config, cwd, identity)),
-    Effect.ignoreCause,
-  );
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    // Index-only homes never store private deferred intents. Skip before
+    // getRuntimeConfig so post-index heal cannot hold the ApplicationLayer
+    // scope open long enough for opportunistic graph maintenance to open
+    // extra SQLite sessions.
+    const dataRoot = path.join(threadnoteHome, 'data');
+    const info = yield* fs.stat(dataRoot).pipe(Effect.option);
+    if (Option.isNone(info) || info.value.type !== 'Directory') return;
+    const config = yield* getRuntimeConfig({home: threadnoteHome});
+    yield* healAnchorsAfterGraphIndex(config, cwd, identity);
+  }).pipe(Effect.ignoreCause);
 
 type PublishedGraphIndexHealServices = Effect.Services<ReturnType<typeof publishedGraphIndexHeal>>;
 

--- a/test/unit/deferred-code-anchor-index-heal.test.ts
+++ b/test/unit/deferred-code-anchor-index-heal.test.ts
@@ -15,7 +15,10 @@ import {
   isDeferredCodeAnchorIntentFilename,
   stageDeferredCodeAnchorIntent,
 } from '../../src/memory/deferred_code_anchor.js';
-import {withDeferredCodeAnchorIndexHeal} from '../../src/memory/deferred_code_anchor_index_heal.js';
+import {
+  healAfterPublishedGraphIndex,
+  withDeferredCodeAnchorIndexHeal,
+} from '../../src/memory/deferred_code_anchor_index_heal.js';
 import {
   DeferredCodeAnchorRefreshScheduler,
   refreshPendingDeferredCodeAnchorWorkspaces,
@@ -111,6 +114,38 @@ describe('in-process graph-index deferred-anchor recovery', () => {
       expect(healed).toEqual([]);
     });
   });
+
+  effectIt.effect('skips published-graph heal when the Threadnote home has no data tree', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-heal-absent-data-'});
+        yield* healAfterPublishedGraphIndex(home, home, {
+          repositoryId: 'a'.repeat(64),
+          worktreeId: 'b'.repeat(64),
+        });
+        expect(yield* fs.exists(path.join(home, 'data'))).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('skips published-graph heal when data is not a directory', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-heal-data-file-'});
+        const dataPath = path.join(home, 'data');
+        yield* fs.writeFileString(dataPath, 'not-a-tree\n');
+        yield* healAfterPublishedGraphIndex(home, home, {
+          repositoryId: 'a'.repeat(64),
+          worktreeId: 'b'.repeat(64),
+        });
+        expect(yield* fs.readFileString(dataPath)).toBe('not-a-tree\n');
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
 
   effectIt.effect(
     'finalizes a matching intent after ApplicationLayer in-process index',


### PR DESCRIPTION
## Summary
- Skip deferred-anchor heal after a published graph index unless `threadnoteHome/data` is a directory, so index-only homes do not keep ApplicationLayer alive for extra SQLite opens.
- Ships that regression fix as Threadnote 4.6.11.

## Test plan
- [x] Focused unit + session tests for the empty-data skip
- [ ] CI Tests · long · heavy-integration green on this SHA
- [ ] Remaining required CI green, then squash-merge with admin bypass
- [ ] Tag `v4.6.11` on the exact protected-main commit